### PR TITLE
Fix for `Orbits.configure()` when specifying time array

### DIFF
--- a/lisatools/detector.py
+++ b/lisatools/detector.py
@@ -229,6 +229,8 @@ class Orbits(ABC):
                 t_arr = np.concatenate([t_arr, self.t_base[-1:]])
         elif t_arr is not None:
             assert np.all(t_arr >= self.t_base[0]) and np.all(t_arr <= self.t_base[-1])
+            make_cpp = True
+            dt = abs(t_arr[1] - t_arr[0])
 
         elif dt is not None:
             make_cpp = True


### PR DESCRIPTION
I encountered an error when calling `Orbits.configure` with a time array input. Calling the method in this way returns an `UnboundLocalError` that points to an unset flag `make_cpp` in `detector.py`. I have added a line that sets `make_cpp = True` when specifying a time array. Additionally, I have added a line that calculates `dt` by taking the step size between the first two elements of the input, since otherwise `dt` is not automatically set. These fixes resolve the errors I encountered and should allow for proper orbit file initialization with a user-input time array.