### PR TITLE
Making char_strain calculation consistent

### DIFF
--- a/lisatools/datacontainer.py
+++ b/lisatools/datacontainer.py
@@ -300,7 +300,7 @@ class DataResidualArray:
         for i, ax_tmp in zip(inds_list, ax):
             plot_in = np.abs(self.data_res_arr[i])
             if char_strain:
-                plot_in *= self.frequency_arr
+                plot_in *= 2 * self.frequency_arr
             ax_tmp.loglog(self.frequency_arr, plot_in, **kwargs)
 
         return (fig, ax)
@@ -308,4 +308,4 @@ class DataResidualArray:
     @property
     def char_strain(self) -> np.ndarray:
         """Characteristic strain representation of the data."""
-        return np.sqrt(self.f_arr) * np.abs(self.data_res_arr)
+        return 2 * self.f_arr * np.abs(self.data_res_arr)


### PR DESCRIPTION
I'm not sure characteristic strain is being calculated correctly in `DataResidualArray` 

The calculation appears inconsistent between the `char_strain` property and the `loglog()` in that the two calculations have different units.

[This paper](https://arxiv.org/pdf/1408.0740) seems to have a definition in terms of Fourier coefficients in equation 17, which I've transcribed in the diff. It is very close to the calculation done in `loglog()`

I'm relying on the DFT done with time domain signals [here in DataResidualArray](https://github.com/mikekatz04/LISAanalysistools/blob/55ae69fdcc201cf088cbb9e7490985f9d3073095/lisatools/datacontainer.py#L112) to infer that data_res_arr has units of signal/Hz, and that an analogy to continuous fourier coefficients is reasonable for the intended data representation in a `DataResidualArray`

I'm also relying on [this calculation in `SensitiviityMatrix.loglog`](https://github.com/mikekatz04/LISAanalysistools/blob/55ae69fdcc201cf088cbb9e7490985f9d3073095/lisatools/sensitivity.py#L726) which appears to implement equation 18 from that same paper.

I am just learning about the details of the units here for this sort of data analysis. If what I am saying above is in error I would very much appreciate any correction you might offer.