### PR TITLE
Retire DomainComputationGroupArray into AnalysisContainerArray (+ real-kernel FD/STFT tests)

### DIFF
--- a/src/lisatools/analysiscontainer.py
+++ b/src/lisatools/analysiscontainer.py
@@ -1506,7 +1506,7 @@ class AnalysisContainerArray:
             split structure used for GPUs (``gpu_splits`` / ``split_map`` /
             per-split linear buffers). One thread per split is then driven by
             the ACA's own per-split C++ likelihood coordinator (the
-            :attr:`cpp_splits` strategies + :meth:`compute_signal_likelihood`)
+            :attr:`cpp_splits` strategies + :meth:`cpp_signal_likelihood`)
             with ``run_threaded=True`` exactly as in the multi-GPU case (each
             split's strategy holds its own workspaces, so threads never share
             scratch buffers). Threads pay off where the per-split
@@ -2185,7 +2185,7 @@ class AnalysisContainerArray:
     def cpp_likelihood_backend(self) -> "DomainComputationGroupArray":
         """Deprecated-compat handle: a thin ``DomainComputationGroupArray``
         shim forwarding to this ACA. Prefer the ACA methods directly
-        (:meth:`cpp_template_likelihood`, :meth:`compute_signal_likelihood`,
+        (:meth:`cpp_template_likelihood`, :meth:`cpp_signal_likelihood`,
         :attr:`cpp_splits`)."""
         self._ensure_cpp_splits()
         if self._cpp_likelihood_backend is None:
@@ -2448,7 +2448,7 @@ class AnalysisContainerArray:
             )
         return output
 
-    def compute_psd_likelihood(
+    def cpp_psd_likelihood(
         self,
         positions_per_split,
         data_intra_per_split,
@@ -2457,7 +2457,11 @@ class AnalysisContainerArray:
         likelihood_kwargs=None,
         run_threaded=False,
     ):
-        """Batched PSD likelihood across splits (aggregated ``(N,)`` host)."""
+        """Batched PSD likelihood across splits (aggregated ``(N,)`` host).
+
+        The ``cpp_`` prefix marks this as the fast C++ batched-kernel path
+        (as opposed to the diagnostic ``likelihood`` family); it is the
+        PSD likelihood driven by the PSD proposal."""
         self._ensure_cpp_splits()
         operations = [s.compute_psd_likelihood for s in self._cpp_splits]
         return self._compute_group_likelihood(
@@ -2470,7 +2474,7 @@ class AnalysisContainerArray:
             run_threaded=run_threaded,
         )
 
-    def compute_signal_likelihood(
+    def cpp_signal_likelihood(
         self,
         positions_per_split,
         data_intra_per_split,
@@ -2481,6 +2485,7 @@ class AnalysisContainerArray:
     ):
         """Batched signal likelihood across splits (aggregated ``(N,)`` host).
 
+        The ``cpp_`` prefix marks this as the fast C++ batched-kernel path.
         This is the per-split-routed core; :meth:`cpp_template_likelihood` is
         the flat-batch entry point that scatters templates into it."""
         self._ensure_cpp_splits()
@@ -2730,7 +2735,7 @@ class AnalysisContainerArray:
         )
 
         # 4) batched (d|h)/(h|h) kernels + cached (d|d) -> aggregated (N,) host.
-        return self.compute_signal_likelihood(
+        return self.cpp_signal_likelihood(
             positions_per_split=positions,
             data_intra_per_split=data_intra,
             noise_intra_per_split=noise_intra,

--- a/src/lisatools/analysiscontainer.py
+++ b/src/lisatools/analysiscontainer.py
@@ -6,6 +6,7 @@ import math
 import warnings
 from abc import ABC
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 import logging
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 
@@ -1552,7 +1553,8 @@ class AnalysisContainerArray:
         # on first access to :attr:`cpp_likelihood_backend`; see that
         # property for why construction must be deferred past ``__init__``.
         self._domain_group_kwargs = dict(domain_group_kwargs) if domain_group_kwargs else {}
-        self._cpp_likelihood_backend = None
+        self._cpp_splits = None             # per-split C++ strategy workspaces
+        self._cpp_likelihood_backend = None  # cached deprecated DCGA shim
 
         if isinstance(analysis_containers, AnalysisContainer):
             acs = np.array([analysis_containers], dtype=object)
@@ -1712,6 +1714,13 @@ class AnalysisContainerArray:
                     )
                 )
             self.split_map[split] = i
+
+        # Routing table for the C++ likelihood coordinator: global AC id ->
+        # intra-split index (what the per-split strategies expect for
+        # data_index / noise_index). ``ac_to_split`` is ``split_map``.
+        self.ac_to_intra = np.empty(self.acs_total_entries, dtype=np.int32)
+        for split_id, ids in enumerate(gpu_splits):
+            self.ac_to_intra[ids] = np.arange(len(ids), dtype=np.int32)
 
         self.num_acs = len(acs.flatten())
         self.reset_linear_data_arr()
@@ -2074,53 +2083,111 @@ class AnalysisContainerArray:
         return self._thread_pool
 
     # ------------------------------------------------------------------
-    # C++ likelihood backend (owned DomainComputationGroupArray)
+    # C++ likelihood coordinator (absorbed from DomainComputationGroupArray)
     # ------------------------------------------------------------------
+    # ACA owns the per-split C++ strategy workspaces (the STFT/FD/WDM
+    # *ComputationGroup objects) and the batched multi-split orchestration
+    # directly. The legacy ``DomainComputationGroupArray`` is now a thin
+    # forwarding shim over these methods. The same C++ kernels run on CPU
+    # (host compiler) and GPU (``nvcc``) — the "cpp" fast path, distinct from
+    # the slow per-AC ``diagnostic`` path behind ``calculate_signal_likelihood``
+    # / ``template_likelihood`` (which stays as the general + validation path).
+
+    @property
+    def num_splits(self) -> int:
+        return len(self.gpu_splits)
+
+    @property
+    def ac_to_split(self) -> np.ndarray:
+        """Global AC id -> owning split index (alias of ``split_map``)."""
+        return self.split_map
 
     @property
     def domain_group_kwargs(self) -> dict:
-        """Kwargs forwarded to the owned C++ likelihood backend's per-split
-        computation groups (e.g. ``tdi_type``, and STFT's ``window_alpha`` /
-        ``use_midpoint``). Reassigning invalidates the cached backend so it is
-        rebuilt with the new kwargs on next access."""
+        """Kwargs forwarded to the per-split C++ strategies (e.g. ``tdi_type``,
+        and STFT's ``window_alpha`` / ``use_midpoint``). Reassigning rebuilds
+        the strategies on next access."""
         return self._domain_group_kwargs
 
     @domain_group_kwargs.setter
     def domain_group_kwargs(self, value: Optional[dict]) -> None:
         self._domain_group_kwargs = dict(value) if value else {}
-        self._cpp_likelihood_backend = None  # force rebuild on next access
+        self._cpp_splits = None              # force strategy rebuild
+        self._cpp_likelihood_backend = None  # and drop the shim cache
+
+    def _cpp_strategy_class(self):
+        """Per-domain strategy class paired with ``settings`` (isinstance
+        dispatch — never a string flag)."""
+        # Deferred import: ``domaincomputation`` imports this module only under
+        # TYPE_CHECKING, so importing here keeps the runtime graph acyclic.
+        from .domaincomputation import (
+            STFTComputationGroup,
+            FDComputationGroup,
+            WDMComputationGroup,
+        )
+
+        if isinstance(self.settings, domains.STFTSettings):
+            return STFTComputationGroup
+        if isinstance(self.settings, domains.FDSettings):
+            return FDComputationGroup
+        if isinstance(self.settings, domains.WDMSettings):
+            return WDMComputationGroup
+        raise NotImplementedError(
+            f"Unsupported domain settings type {type(self.settings).__name__} "
+            f"for the C++ likelihood coordinator."
+        )
+
+    def _build_cpp_splits(self) -> None:
+        """Build the per-split C++ strategy workspaces and snapshot ``(d|d)``.
+
+        Deferred to first access (never in ``__init__``): each strategy
+        precomputes ``(d|d)`` from each AC's ``inner_product()`` off the
+        per-split ``linear_*_arr`` buffers, which are only populated at the end
+        of ``__init__`` (``reset_linear_*_arr``).
+        """
+        force_backend = "cpu" if self.gpus is None else "gpu"
+        cls = self._cpp_strategy_class()
+        splits = []
+        for split_index in range(self.num_splits):
+            device = self.gpus[split_index] if self.gpus is not None else None
+            with self.device_context(device):
+                splits.append(
+                    cls(
+                        acs=self,
+                        split_index=split_index,
+                        force_backend=force_backend,
+                        **self._domain_group_kwargs,
+                    )
+                )
+        self._cpp_splits = splits
+        self.compute_d_d_terms()
+
+    def _ensure_cpp_splits(self) -> None:
+        if self._cpp_splits is None:
+            self._build_cpp_splits()
+
+    @property
+    def cpp_splits(self) -> list:
+        """The per-split C++ strategy workspaces (lazily built)."""
+        self._ensure_cpp_splits()
+        return self._cpp_splits
+
+    def cpp_split(self, i: int):
+        """The C++ strategy workspace for split ``i`` (exposes ``.orbits`` /
+        ``.sensitivity_backend`` / ``.cpp_domain``)."""
+        return self.cpp_splits[i]
 
     @property
     def cpp_likelihood_backend(self) -> "DomainComputationGroupArray":
-        """Lazily build and cache the owned C++ likelihood backend.
-
-        The same C++ kernels run on CPU (host compiler) and GPU (``nvcc``);
-        this is the "cpp" fast path, distinct from the slow per-AC
-        ``diagnostic`` path behind :meth:`calculate_signal_likelihood` /
-        :meth:`template_likelihood`.
-
-        Builds a :class:`~lisatools.domaincomputation.DomainComputationGroupArray`
-        against ``self`` (so it is keyed to this ACA's ``gpu_splits`` /
-        ``split_map`` / ``linear_*_arr`` / ``settings``; STFT/FD/WDM dispatch
-        is automatic on ``settings``). The per-split computation groups are
-        configured from :attr:`domain_group_kwargs`.
-
-        Construction is deferred to first access (never inside ``__init__``)
-        because the backend precomputes ``(d|d)`` per split, which reads each
-        AC's ``inner_product()`` off ``linear_data_arr`` / ``linear_psd_arr`` —
-        buffers only populated at the *end* of ``__init__``
-        (``reset_linear_*_arr``). ``(d|d)`` is a snapshot at build time; after
-        mutating residuals call :meth:`refresh_cpp_dd`.
-        """
+        """Deprecated-compat handle: a thin ``DomainComputationGroupArray``
+        shim forwarding to this ACA. Prefer the ACA methods directly
+        (:meth:`cpp_template_likelihood`, :meth:`compute_signal_likelihood`,
+        :attr:`cpp_splits`)."""
+        self._ensure_cpp_splits()
         if self._cpp_likelihood_backend is None:
-            # Deferred import: ``domaincomputation`` imports this module only
-            # under TYPE_CHECKING, so importing it here (not at module top)
-            # keeps the runtime import graph acyclic.
             from .domaincomputation import DomainComputationGroupArray
 
-            self._cpp_likelihood_backend = DomainComputationGroupArray(
-                self, self._domain_group_kwargs
-            )
+            self._cpp_likelihood_backend = DomainComputationGroupArray(self)
         return self._cpp_likelihood_backend
 
     @property
@@ -2129,16 +2196,300 @@ class AnalysisContainerArray:
         return self.cpp_likelihood_backend
 
     def refresh_cpp_dd(self, **kwargs) -> None:
-        """Recompute the owned C++ backend's cached ``(d|d)`` per split.
+        """Recompute the cached ``(d|d)`` per split after mutating residuals
+        (e.g. :meth:`signal_operation`). No-op if the strategies are not built
+        yet. ``kwargs`` are forwarded to each container's ``inner_product``."""
+        if self._cpp_splits is not None:
+            self.compute_d_d_terms(**kwargs)
 
-        Call after mutating residuals (e.g. :meth:`signal_operation`, or any
-        path that rewrites the per-split linear data buffers) so that
-        :meth:`cpp_template_likelihood` reflects the new data. No-op if the
-        backend has not been built yet. ``kwargs`` are forwarded to each
-        container's ``inner_product``.
-        """
-        if self._cpp_likelihood_backend is not None:
-            self._cpp_likelihood_backend.compute_d_d_terms(**kwargs)
+    # ---- device / memory helpers (moved from DomainComputationGroupArray) ----
+
+    @contextmanager
+    def device_context(self, device: int = None):
+        """Set the device context for a split: a specific GPU, or CPU (which
+        also pins JAX's default device)."""
+        if device is None or self.gpus is None:
+            import jax  # lazy: keep ``import lisatools.analysiscontainer`` jax-free
+
+            with jax.default_device(jax.devices("cpu")[0]):
+                yield "cpu"
+        else:
+            with self.xp.cuda.Device(device):
+                yield f"gpu: {device}"
+
+    def free_gpu_memory(self) -> None:
+        """Free the cupy default memory pool on every GPU split."""
+        if self.gpus is not None:
+            for device in self.gpus:
+                with self.device_context(device):
+                    self.xp.get_default_memory_pool().free_all_blocks()
+
+    def _to_host(self, arr) -> np.ndarray:
+        """Move an array to host numpy (no-op if already numpy)."""
+        return arr.get() if hasattr(arr, "get") else arr
+
+    # ---- routing / scatter (moved from DomainComputationGroupArray) ----
+
+    def unpack_indices(self, data_index, noise_index=None):
+        """Partition a flat ``(data_index, noise_index)`` batch by split.
+
+        Returns three parallel lists of length ``num_splits``:
+        ``positions_per_split`` (flat-batch positions per split; empty arrays
+        for splits with no matching ACs), ``data_intra_per_split`` and
+        ``noise_intra_per_split`` (intra-split AC ids). Single owner of the
+        partition — downstream routines share its output."""
+        data_index_cpu = self._to_host(data_index)
+        noise_index_cpu = (
+            self._to_host(noise_index) if noise_index is not None else data_index_cpu
+        )
+
+        split_of_each = self.ac_to_split[data_index_cpu]
+
+        positions_per_split: list = []
+        data_intra_per_split: list = []
+        noise_intra_per_split: list = []
+        for split_id in range(self.num_splits):
+            positions = np.where(split_of_each == split_id)[0]
+            positions_per_split.append(positions)
+            data_intra_per_split.append(self.ac_to_intra[data_index_cpu[positions]])
+            noise_intra_per_split.append(self.ac_to_intra[noise_index_cpu[positions]])
+
+        return positions_per_split, data_intra_per_split, noise_intra_per_split
+
+    def unpack_coords(self, positions_per_split, coords, keep_tuple=False):
+        """Slice flat coordinate array(s) per split (Fortran-ordered host
+        copies); returns ``()`` for empty splits. ``keep_tuple`` wraps the
+        single-array case in a 1-tuple."""
+        if not isinstance(coords, tuple):
+            coords = (coords,)
+
+        coords_host = tuple(self._to_host(coords_here) for coords_here in coords)
+
+        args_per_group: list = []
+        for positions in positions_per_split:
+            if len(positions) > 0:
+                coords_s = [
+                    np.asfortranarray(coords_host[i][positions])
+                    for i in range(len(coords_host))
+                ]
+                args_per_group.append(
+                    tuple(coords_s) if len(coords_s) > 1 or keep_tuple else coords_s[0]
+                )
+            else:
+                args_per_group.append(())
+
+        return args_per_group
+
+    def place_on_device(self, items):
+        """Place a tuple of per-split array/tuple lists on each split's device
+        (``self.xp.asarray(copy=True)``); empty tuples pass through."""
+        num_items = len(items)
+        device_items: list = [[] for _ in range(num_items)]
+
+        for i, device in enumerate(
+            self.gpus if self.gpus is not None else [None] * self.num_splits
+        ):
+            with self.device_context(device):
+                for item_id, item_per_split in enumerate(items):
+                    entry = item_per_split[i]
+                    if isinstance(entry, np.ndarray):
+                        device_items[item_id].append(self.xp.asarray(entry, copy=True))
+                    elif isinstance(entry, tuple):
+                        if len(entry) == 0:
+                            device_items[item_id].append(())
+                        else:
+                            device_items[item_id].append(
+                                tuple(self.xp.asarray(arr, copy=True) for arr in entry)
+                            )
+                    else:
+                        raise ValueError(
+                            "Each entry in items must be either a numpy array or a "
+                            "tuple of numpy arrays."
+                        )
+        return tuple(device_items)
+
+    def _loop_operation(
+        self,
+        operation,
+        operation_args_per_split=None,
+        operation_kwargs=None,
+        aggregate_fn=None,
+        positions_per_split=None,
+        run_threaded=False,
+    ):
+        """General per-split dispatch (return-collecting; visits all splits;
+        empty splits short-circuit to ``None`` via ``positions_per_split``).
+
+        Distinct from :meth:`_run_per_split` (worker+rows, populated-only,
+        writes into a shared results buffer) used by the slow vectorized path.
+        ``operation`` may be a single callable or one per split; results are
+        index-aligned to splits, optionally reduced by ``aggregate_fn``."""
+        if operation_args_per_split is None:
+            operation_args_per_split = [()] * self.num_splits
+        if operation_kwargs is None:
+            operation_kwargs = {}
+
+        if len(operation_args_per_split) != self.num_splits:
+            raise ValueError(
+                "Length of operation_args_per_split must match the number of splits."
+            )
+
+        if isinstance(operation, list):
+            if len(operation) != self.num_splits:
+                raise ValueError(
+                    "If operation is a list, its length must match the number of splits."
+                )
+            operations = operation
+        else:
+            operations = [operation] * self.num_splits
+
+        if isinstance(operation_kwargs, list):
+            if len(operation_kwargs) != self.num_splits:
+                raise ValueError(
+                    "If operation_kwargs is a list, its length must match the number of splits."
+                )
+            operation_kwargs_per_split = operation_kwargs
+        else:
+            operation_kwargs_per_split = [operation_kwargs] * self.num_splits
+
+        devices = self.gpus if self.gpus is not None else [None] * self.num_splits
+
+        def _run_split_operation(i, device):
+            if positions_per_split is not None and len(positions_per_split[i]) == 0:
+                return None
+            with self.device_context(device):
+                return operations[i](
+                    *operation_args_per_split[i], **operation_kwargs_per_split[i]
+                )
+
+        if run_threaded:
+            futures = [
+                self.thread_pool.submit(_run_split_operation, i, device)
+                for i, device in enumerate(devices)
+            ]
+            outputs = [future.result() for future in futures]
+        else:
+            outputs = []
+            for i, device in enumerate(devices):
+                outputs.append(_run_split_operation(i, device))
+
+        if aggregate_fn is not None:
+            return aggregate_fn(outputs)
+        return outputs
+
+    # ---- batched likelihood orchestration (moved from DCGA) ----
+
+    def compute_d_d_terms(self, out: bool = False, **kwargs):
+        """Compute ``(d|d)`` for all splits, storing it on each strategy."""
+        self._ensure_cpp_splits()
+        operations = [s.compute_d_d_term for s in self._cpp_splits]
+        list_out = self._loop_operation(
+            operation=operations, operation_kwargs={"out": out, **kwargs}
+        )
+        if out:
+            return list_out
+
+    def compute_noise_terms(self, out: bool = False, **kwargs):
+        """Compute the noise log-likelihood term for all splits."""
+        self._ensure_cpp_splits()
+        operations = [s.compute_noise_term for s in self._cpp_splits]
+        list_out = self._loop_operation(
+            operation=operations, operation_kwargs={"out": out, **kwargs}
+        )
+        if out:
+            return list_out
+
+    def _compute_group_likelihood(
+        self,
+        positions_per_split,
+        data_intra_per_split,
+        noise_intra_per_split,
+        operations,
+        likelihood_args_per_split,
+        likelihood_kwargs=None,
+        run_threaded=False,
+    ):
+        """Run per-split likelihood ``operations`` and scatter the results back
+        into a single flat ``(N,)`` host array in original input order."""
+        operation_args_per_split = []
+        for split_id in range(self.num_splits):
+            likelihood_args = likelihood_args_per_split[split_id]
+            args_i = (
+                data_intra_per_split[split_id],
+                noise_intra_per_split[split_id],
+                *(likelihood_args if likelihood_args is not None else ()),
+            )
+            operation_args_per_split.append(args_i)
+
+        all_logls = self._loop_operation(
+            operation=operations,
+            operation_args_per_split=operation_args_per_split,
+            operation_kwargs=likelihood_kwargs,
+            positions_per_split=positions_per_split,
+            run_threaded=run_threaded,
+        )
+
+        self.synchronize()
+        n_data = sum(len(p) for p in positions_per_split)
+
+        output = np.full(n_data, -1e300, dtype=np.float64)
+        for split_id, positions in enumerate(positions_per_split):
+            if len(positions) > 0:
+                output[positions] = self._to_host(all_logls[split_id])
+
+        if np.any(output == -1e300):
+            logger.warning(
+                "Some positions were not filled in the output array. This may "
+                "indicate an issue with the likelihood computation or aggregation."
+            )
+        return output
+
+    def compute_psd_likelihood(
+        self,
+        positions_per_split,
+        data_intra_per_split,
+        noise_intra_per_split,
+        likelihood_args_per_split,
+        likelihood_kwargs=None,
+        run_threaded=False,
+    ):
+        """Batched PSD likelihood across splits (aggregated ``(N,)`` host)."""
+        self._ensure_cpp_splits()
+        operations = [s.compute_psd_likelihood for s in self._cpp_splits]
+        return self._compute_group_likelihood(
+            positions_per_split,
+            data_intra_per_split,
+            noise_intra_per_split,
+            operations,
+            likelihood_args_per_split,
+            likelihood_kwargs=likelihood_kwargs,
+            run_threaded=run_threaded,
+        )
+
+    def compute_signal_likelihood(
+        self,
+        positions_per_split,
+        data_intra_per_split,
+        noise_intra_per_split,
+        likelihood_args_per_split,
+        likelihood_kwargs=None,
+        run_threaded=False,
+    ):
+        """Batched signal likelihood across splits (aggregated ``(N,)`` host).
+
+        This is the per-split-routed core; :meth:`cpp_template_likelihood` is
+        the flat-batch entry point that scatters templates into it."""
+        self._ensure_cpp_splits()
+        operations = [s.compute_signal_likelihood for s in self._cpp_splits]
+        return self._compute_group_likelihood(
+            positions_per_split,
+            data_intra_per_split,
+            noise_intra_per_split,
+            operations,
+            likelihood_args_per_split,
+            likelihood_kwargs=likelihood_kwargs,
+            run_threaded=run_threaded,
+        )
 
     def _split_rows(self, index_arr: np.ndarray) -> dict:
         """Group flat row positions by owning split: ``{split: rows}``."""
@@ -2350,7 +2701,7 @@ class AnalysisContainerArray:
         if run_threaded is None:
             run_threaded = self.run_threaded
 
-        dcga = self.cpp_likelihood_backend
+        self._ensure_cpp_splits()
 
         template_vals = self.xp.asarray(template_vals, dtype=self.data_dtype)
         start_freqs = self.xp.asarray(start_freqs, dtype=self.xp.float64)
@@ -2359,7 +2710,7 @@ class AnalysisContainerArray:
 
         # 1) partition the flat batch by owning split (single owner of the
         #    partition; ``noise_index=None`` -> ``data_index`` inside).
-        positions, data_intra, noise_intra = dcga.unpack_indices(data_index, noise_index)
+        positions, data_intra, noise_intra = self.unpack_indices(data_index, noise_index)
 
         # 2) scatter templates / start_freqs [/ start_times] per split, in the
         #    positional order ``compute_signal_likelihood_terms`` expects.
@@ -2367,15 +2718,15 @@ class AnalysisContainerArray:
             coords = (template_vals, start_freqs)
         else:
             coords = (template_vals, start_freqs, start_times)
-        coords_per_split = dcga.unpack_coords(positions, coords, keep_tuple=True)
+        coords_per_split = self.unpack_coords(positions, coords, keep_tuple=True)
 
         # 3) place intra-indices + scattered coords on each split's device.
-        data_intra, noise_intra, coords_per_split = dcga.place_on_device(
+        data_intra, noise_intra, coords_per_split = self.place_on_device(
             (data_intra, noise_intra, coords_per_split)
         )
 
         # 4) batched (d|h)/(h|h) kernels + cached (d|d) -> aggregated (N,) host.
-        return dcga.compute_signal_likelihood(
+        return self.compute_signal_likelihood(
             positions_per_split=positions,
             data_intra_per_split=data_intra,
             noise_intra_per_split=noise_intra,

--- a/src/lisatools/analysiscontainer.py
+++ b/src/lisatools/analysiscontainer.py
@@ -1668,7 +1668,7 @@ class AnalysisContainerArray:
         else:
             # CPU-thread splits (no GPUs): ``n_splits`` shards the containers
             # through the same split structure as multi-GPU, one thread per
-            # split downstream (DCGA run_threaded). With GPUs, the split
+            # split downstream (ACA run_threaded). With GPUs, the split
             # count is always len(gpus). (Arg validation happens above,
             # before any device work.)
             num_machines = (

--- a/src/lisatools/analysiscontainer.py
+++ b/src/lisatools/analysiscontainer.py
@@ -1519,6 +1519,13 @@ class AnalysisContainerArray:
             concurrently, one thread per split (GPU splits each enter their
             own device context; CPU splits rely on GIL-releasing work). The
             default ``False`` preserves the serial per-split loops.
+        domain_group_kwargs: Kwargs forwarded to the owned C++ likelihood
+            backend's per-split computation groups (e.g. ``tdi_type`` for all
+            domains, and STFT's ``window_alpha`` / ``use_midpoint``). Drives
+            :meth:`cpp_template_likelihood` via the lazily-built
+            :attr:`cpp_likelihood_backend`. May also be set later through the
+            :attr:`domain_group_kwargs` property (which invalidates the cached
+            backend).
 
     """
 
@@ -1535,9 +1542,17 @@ class AnalysisContainerArray:
         gpu_assignment: Optional[np.ndarray] = None,
         n_splits: Optional[int] = None,
         run_threaded: bool = False,
+        domain_group_kwargs: Optional[dict] = None,
     ) -> None:
         self.run_threaded = bool(run_threaded)
         self._thread_pool = None
+
+        # Lazily-built C++ likelihood backend (a
+        # ``DomainComputationGroupArray`` keyed to this ACA's splits). Built
+        # on first access to :attr:`cpp_likelihood_backend`; see that
+        # property for why construction must be deferred past ``__init__``.
+        self._domain_group_kwargs = dict(domain_group_kwargs) if domain_group_kwargs else {}
+        self._cpp_likelihood_backend = None
 
         if isinstance(analysis_containers, AnalysisContainer):
             acs = np.array([analysis_containers], dtype=object)
@@ -2058,6 +2073,73 @@ class AnalysisContainerArray:
             )
         return self._thread_pool
 
+    # ------------------------------------------------------------------
+    # C++ likelihood backend (owned DomainComputationGroupArray)
+    # ------------------------------------------------------------------
+
+    @property
+    def domain_group_kwargs(self) -> dict:
+        """Kwargs forwarded to the owned C++ likelihood backend's per-split
+        computation groups (e.g. ``tdi_type``, and STFT's ``window_alpha`` /
+        ``use_midpoint``). Reassigning invalidates the cached backend so it is
+        rebuilt with the new kwargs on next access."""
+        return self._domain_group_kwargs
+
+    @domain_group_kwargs.setter
+    def domain_group_kwargs(self, value: Optional[dict]) -> None:
+        self._domain_group_kwargs = dict(value) if value else {}
+        self._cpp_likelihood_backend = None  # force rebuild on next access
+
+    @property
+    def cpp_likelihood_backend(self) -> "DomainComputationGroupArray":
+        """Lazily build and cache the owned C++ likelihood backend.
+
+        The same C++ kernels run on CPU (host compiler) and GPU (``nvcc``);
+        this is the "cpp" fast path, distinct from the slow per-AC
+        ``diagnostic`` path behind :meth:`calculate_signal_likelihood` /
+        :meth:`template_likelihood`.
+
+        Builds a :class:`~lisatools.domaincomputation.DomainComputationGroupArray`
+        against ``self`` (so it is keyed to this ACA's ``gpu_splits`` /
+        ``split_map`` / ``linear_*_arr`` / ``settings``; STFT/FD/WDM dispatch
+        is automatic on ``settings``). The per-split computation groups are
+        configured from :attr:`domain_group_kwargs`.
+
+        Construction is deferred to first access (never inside ``__init__``)
+        because the backend precomputes ``(d|d)`` per split, which reads each
+        AC's ``inner_product()`` off ``linear_data_arr`` / ``linear_psd_arr`` —
+        buffers only populated at the *end* of ``__init__``
+        (``reset_linear_*_arr``). ``(d|d)`` is a snapshot at build time; after
+        mutating residuals call :meth:`refresh_cpp_dd`.
+        """
+        if self._cpp_likelihood_backend is None:
+            # Deferred import: ``domaincomputation`` imports this module only
+            # under TYPE_CHECKING, so importing it here (not at module top)
+            # keeps the runtime import graph acyclic.
+            from .domaincomputation import DomainComputationGroupArray
+
+            self._cpp_likelihood_backend = DomainComputationGroupArray(
+                self, self._domain_group_kwargs
+            )
+        return self._cpp_likelihood_backend
+
+    @property
+    def domain_computation_group(self) -> "DomainComputationGroupArray":
+        """Alias for :attr:`cpp_likelihood_backend`."""
+        return self.cpp_likelihood_backend
+
+    def refresh_cpp_dd(self, **kwargs) -> None:
+        """Recompute the owned C++ backend's cached ``(d|d)`` per split.
+
+        Call after mutating residuals (e.g. :meth:`signal_operation`, or any
+        path that rewrites the per-split linear data buffers) so that
+        :meth:`cpp_template_likelihood` reflects the new data. No-op if the
+        backend has not been built yet. ``kwargs`` are forwarded to each
+        container's ``inner_product``.
+        """
+        if self._cpp_likelihood_backend is not None:
+            self._cpp_likelihood_backend.compute_d_d_terms(**kwargs)
+
     def _split_rows(self, index_arr: np.ndarray) -> dict:
         """Group flat row positions by owning split: ``{split: rows}``."""
         split_per_row = self.split_map[np.asarray(index_arr, dtype=int)]
@@ -2208,6 +2290,98 @@ class AnalysisContainerArray:
             payload=template,
             index=index,
             op_kwargs=kwargs,
+        )
+
+    def cpp_template_likelihood(
+        self,
+        data_index,
+        template_vals,
+        start_freqs,
+        start_times=None,
+        noise_index=None,
+        run_threaded=None,
+        run_async: bool = False,
+    ) -> np.ndarray:
+        r"""Fast batched signal log-likelihood from pre-generated templates,
+        via the owned C++ backend.
+
+        Drives the multi-split propagation through
+        :attr:`cpp_likelihood_backend` (a ``DomainComputationGroupArray``),
+        evaluating
+
+        .. math:: -\tfrac{1}{2}\,\bigl((d|d) + (h|h) - 2\,\mathrm{Re}(d|h)\bigr)
+
+        for a **flat** batch of pre-generated templates, with the fast C++
+        kernels (``compute_likelihood_terms``) instead of the slow per-AC
+        ``diagnostic`` path used by :meth:`calculate_signal_likelihood` /
+        :meth:`template_likelihood` (which remains the general + validation
+        reference).
+
+        Args:
+            data_index: int array ``(N,)``. Global AC id (equivalently walker
+                id) targeted by each template row.
+            template_vals: template array, leading axis ``N``:
+                ``(N, nchannels, n_t, n_f)`` for STFT,
+                ``(N, nchannels, n_f)`` for FD,
+                ``(N, nchannels, n_m, n_n)`` for WDM. Coerced to
+                :attr:`data_dtype` (``float`` for WDM, ``complex`` otherwise) —
+                the STFT/FD kernels do not coerce, so a wrong-width dtype would
+                silently corrupt; the coercion here is required.
+            start_freqs: float array ``(N,)``. Physical start frequency of each
+                template sub-grid.
+            start_times: float array ``(N,)``. Required for STFT/WDM; unused for
+                FD (pass ``None``).
+            noise_index: int array ``(N,)``; defaults to ``data_index``.
+            run_threaded: per-split threaded dispatch; defaults to
+                :attr:`run_threaded`.
+            run_async: forwarded into the kernel (GPU async alloc/free; no-op on
+                CPU).
+
+        Returns:
+            ``np.ndarray`` of shape ``(N,)`` (host), per-binary log-likelihoods
+            in the original flat input order.
+
+        Notes:
+            ``(d|h)`` / ``(h|h)`` are recomputed every call from the live
+            per-split residual buffers, but ``(d|d)`` is cached at backend
+            build time. After mutating residuals call
+            :meth:`refresh_cpp_dd` before relying on the result.
+        """
+        if run_threaded is None:
+            run_threaded = self.run_threaded
+
+        dcga = self.cpp_likelihood_backend
+
+        template_vals = self.xp.asarray(template_vals, dtype=self.data_dtype)
+        start_freqs = self.xp.asarray(start_freqs, dtype=self.xp.float64)
+        if start_times is not None:
+            start_times = self.xp.asarray(start_times, dtype=self.xp.float64)
+
+        # 1) partition the flat batch by owning split (single owner of the
+        #    partition; ``noise_index=None`` -> ``data_index`` inside).
+        positions, data_intra, noise_intra = dcga.unpack_indices(data_index, noise_index)
+
+        # 2) scatter templates / start_freqs [/ start_times] per split, in the
+        #    positional order ``compute_signal_likelihood_terms`` expects.
+        if start_times is None:
+            coords = (template_vals, start_freqs)
+        else:
+            coords = (template_vals, start_freqs, start_times)
+        coords_per_split = dcga.unpack_coords(positions, coords, keep_tuple=True)
+
+        # 3) place intra-indices + scattered coords on each split's device.
+        data_intra, noise_intra, coords_per_split = dcga.place_on_device(
+            (data_intra, noise_intra, coords_per_split)
+        )
+
+        # 4) batched (d|h)/(h|h) kernels + cached (d|d) -> aggregated (N,) host.
+        return dcga.compute_signal_likelihood(
+            positions_per_split=positions,
+            data_intra_per_split=data_intra,
+            noise_intra_per_split=noise_intra,
+            likelihood_args_per_split=coords_per_split,
+            likelihood_kwargs={"run_async": run_async},
+            run_threaded=run_threaded,
         )
 
     def __getitem__(self, index: Any) -> np.ndarray[AnalysisContainer]:

--- a/src/lisatools/analysiscontainer.py
+++ b/src/lisatools/analysiscontainer.py
@@ -1505,10 +1505,11 @@ class AnalysisContainerArray:
             the containers into this many CPU splits through the **same**
             split structure used for GPUs (``gpu_splits`` / ``split_map`` /
             per-split linear buffers). One thread per split is then driven by
-            :class:`~lisatools.domaincomputation.DomainComputationGroupArray`
+            the ACA's own per-split C++ likelihood coordinator (the
+            :attr:`cpp_splits` strategies + :meth:`compute_signal_likelihood`)
             with ``run_threaded=True`` exactly as in the multi-GPU case (each
-            split's computation group holds its own workspaces, so threads
-            never share scratch buffers). Threads pay off where the per-split
+            split's strategy holds its own workspaces, so threads never share
+            scratch buffers). Threads pay off where the per-split
             work releases the GIL (numpy/BLAS/FFT on large arrays, JAX-CPU,
             GIL-releasing C++ kernels); pin ``OMP_NUM_THREADS`` /
             ``OPENBLAS_NUM_THREADS`` so ``n_splits * blas_threads`` does not
@@ -1520,13 +1521,13 @@ class AnalysisContainerArray:
             concurrently, one thread per split (GPU splits each enter their
             own device context; CPU splits rely on GIL-releasing work). The
             default ``False`` preserves the serial per-split loops.
-        domain_group_kwargs: Kwargs forwarded to the owned C++ likelihood
-            backend's per-split computation groups (e.g. ``tdi_type`` for all
-            domains, and STFT's ``window_alpha`` / ``use_midpoint``). Drives
-            :meth:`cpp_template_likelihood` via the lazily-built
-            :attr:`cpp_likelihood_backend`. May also be set later through the
+        domain_group_kwargs: Kwargs forwarded to the ACA's per-split C++
+            likelihood strategies (e.g. ``tdi_type`` for all domains, and
+            STFT's ``window_alpha`` / ``use_midpoint``). Drives
+            :meth:`cpp_template_likelihood` via the lazily-built per-split
+            strategies (:attr:`cpp_splits`). May also be set later through the
             :attr:`domain_group_kwargs` property (which invalidates the cached
-            backend).
+            strategies).
 
     """
 
@@ -1548,10 +1549,12 @@ class AnalysisContainerArray:
         self.run_threaded = bool(run_threaded)
         self._thread_pool = None
 
-        # Lazily-built C++ likelihood backend (a
-        # ``DomainComputationGroupArray`` keyed to this ACA's splits). Built
-        # on first access to :attr:`cpp_likelihood_backend`; see that
-        # property for why construction must be deferred past ``__init__``.
+        # Lazily-built per-split C++ likelihood state. ``_cpp_splits`` are the
+        # per-split strategy workspaces (built on first access to
+        # :attr:`cpp_splits`; deferred past ``__init__`` because they read the
+        # per-split linear buffers populated at the end of construction).
+        # ``_cpp_likelihood_backend`` caches the deprecated
+        # ``DomainComputationGroupArray`` compat shim.
         self._domain_group_kwargs = dict(domain_group_kwargs) if domain_group_kwargs else {}
         self._cpp_splits = None             # per-split C++ strategy workspaces
         self._cpp_likelihood_backend = None  # cached deprecated DCGA shim
@@ -2087,11 +2090,12 @@ class AnalysisContainerArray:
     # ------------------------------------------------------------------
     # ACA owns the per-split C++ strategy workspaces (the STFT/FD/WDM
     # *ComputationGroup objects) and the batched multi-split orchestration
-    # directly. The legacy ``DomainComputationGroupArray`` is now a thin
-    # forwarding shim over these methods. The same C++ kernels run on CPU
-    # (host compiler) and GPU (``nvcc``) — the "cpp" fast path, distinct from
-    # the slow per-AC ``diagnostic`` path behind ``calculate_signal_likelihood``
-    # / ``template_likelihood`` (which stays as the general + validation path).
+    # directly. The legacy ``DomainComputationGroupArray`` is now only a
+    # deprecated thin alias (kept for external settings files that still
+    # construct it). The same C++ kernels run on CPU (host compiler) and GPU
+    # (``nvcc``) — the "cpp" fast path, distinct from the slow per-AC
+    # ``diagnostic`` path behind ``calculate_signal_likelihood`` /
+    # ``template_likelihood`` (which stays as the general + validation path).
 
     @property
     def num_splits(self) -> int:
@@ -2187,7 +2191,7 @@ class AnalysisContainerArray:
         if self._cpp_likelihood_backend is None:
             from .domaincomputation import DomainComputationGroupArray
 
-            self._cpp_likelihood_backend = DomainComputationGroupArray(self)
+            self._cpp_likelihood_backend = DomainComputationGroupArray(self, _internal=True)
         return self._cpp_likelihood_backend
 
     @property

--- a/src/lisatools/domaincomputation.py
+++ b/src/lisatools/domaincomputation.py
@@ -699,434 +699,100 @@ class WDMComputationGroup(BaseDomainComputationGroup):
 
 
 class DomainComputationGroupArray:
-    """Helper class to manage multiple DomainComputationGroup instances for different splits.
+    """Thin forwarding shim over :class:`AnalysisContainerArray` (deprecated).
 
-    It can perform computations across different GPU splits and aggregate results as needed.
+    The multi-split C++ likelihood coordinator was absorbed into
+    ``AnalysisContainerArray``: it now owns the per-split strategy workspaces
+    (``acs.cpp_splits`` — the STFT/FD/WDM ``*ComputationGroup`` objects) and the
+    batched orchestration directly. This shim forwards every attribute/method to
+    its ``acs`` so existing callers (global-fit moves, external settings files)
+    keep working during the migration.
 
-    Args:
-        acs : AnalysisContainerArray
-            The AnalysisContainerArray containing the data and noise arrays, as well as the GPU split information. This will be used to initialize the individual DomainComputationGroup instances for each split.
+    Prefer the ACA methods directly: ``acs.cpp_template_likelihood`` /
+    ``acs.compute_signal_likelihood`` / ``acs.compute_psd_likelihood`` /
+    ``acs.cpp_splits``.
     """
 
-    def __init__(self, acs: AnalysisContainerArray, domain_group_kwargs: dict[str, Any] = None):
-
+    def __init__(self, acs, domain_group_kwargs=None):
         self.acs = acs
-        
-        self.initialize_computation_groups(domain_group_kwargs)
+        if domain_group_kwargs is not None:
+            # Resets the strategy cache + stores the new kwargs.
+            acs.domain_group_kwargs = domain_group_kwargs
+        acs._ensure_cpp_splits()
 
-        # Precomputed routing tables. ``ac_to_split`` maps a global AC id
-        # (equivalently walker id in the tempered sampler) to the split that
-        # owns it; ``ac_to_intra`` maps the same AC id to its intra-split
-        # index, which is what ``BaseDomainComputationGroup.compute_signal_likelihood``
-        # expects for ``data_index`` / ``noise_index``. Building these once
-        # here replaces per-call ``np.where(...)`` lookups on the hot path.
-        self.ac_to_split = np.asarray(self.acs.split_map)
-        self.ac_to_intra = np.empty(self.acs.acs_total_entries, dtype=np.int32)
-        for split_id, ids in enumerate(self.acs.gpu_splits):
-            self.ac_to_intra[ids] = np.arange(len(ids), dtype=np.int32)
-
-        self._thread_pool = ThreadPoolExecutor(max_workers=self.num_splits)
-
-    def __del__(self):
-        if hasattr(self, "_thread_pool"):
-            self._thread_pool.shutdown(wait=False, cancel_futures=True)
-
-    def initialize_computation_groups(self, domain_group_kwargs: dict[str, Any] = None):
-        """Initializes a DomainComputationGroup instance for each GPU split in the AnalysisContainerArray."""
-
-        force_backend = "cpu" if self.acs.gpus is None else "gpu"
-        settings = self.acs.settings
-        computation_groups: list[BaseDomainComputationGroup] = []
-        for split_index in range(self.num_splits):
-            with self.device_context(
-                self.acs.gpus[split_index] if self.acs.gpus is not None else None
-            ):
-                group = self.computation_group_class(
-                    acs=self.acs,
-                    split_index=split_index,
-                    force_backend=force_backend,
-                    **(domain_group_kwargs or {})
-                )
-                computation_groups.append(group)
-        self.computation_groups = computation_groups
-
-        self.compute_d_d_terms()
-
+    # --- state forwards ---
     @property
-    def xp(self):
-        """Array module (numpy or cupy)."""
-        return self.acs.xp
+    def computation_groups(self):
+        return self.acs.cpp_splits
 
     @property
     def gpus(self):
-        """list of GPU IDs corresponding to each split, or None if using CPU."""
         return self.acs.gpus
 
     @property
-    def main_gpu(self):
-        """GPU ID of the main device, or None if using CPU."""
-        return self.gpus[0] if self.gpus is not None else None
+    def xp(self):
+        return self.acs.xp
 
     @property
     def num_splits(self):
-        return len(self.acs.gpu_splits)
-    
+        return self.acs.num_splits
+
+    @property
+    def main_gpu(self):
+        return self.acs.gpus[0] if self.acs.gpus is not None else None
+
     @property
     def thread_pool(self):
-        """ThreadPoolExecutor for parallel execution across splits"""
-        if not hasattr(self, "_thread_pool"):
-            self._thread_pool = ThreadPoolExecutor(max_workers=self.num_splits)
-            logger.warning("ThreadPoolExecutor not initialized. Initializing with num_splits workers.")
-        return self._thread_pool
+        return self.acs.thread_pool
 
     @property
-    def computation_group_class(self):
-        """The :class:`BaseDomainComputationGroup` subclass paired with the
-        ACA's settings. Dispatch is by :class:`DomainSettingsBase` child
-        class — never a string flag (sprint rule)."""
-        if isinstance(self.acs.settings, STFTSettings):
-            return STFTComputationGroup
-        if isinstance(self.acs.settings, FDSettings):
-            return FDComputationGroup
-        if isinstance(self.acs.settings, WDMSettings):
-            return WDMComputationGroup
-        raise NotImplementedError(
-            f"Unsupported domain settings type "
-            f"{type(self.acs.settings).__name__} for DomainComputationGroupArray."
-        )
+    def ac_to_split(self):
+        return self.acs.ac_to_split
 
-    @contextmanager
-    def device_context(self, device: int = None):
-        """Context manager to set the appropriate device for CPU or GPU backends.
+    @property
+    def ac_to_intra(self):
+        return self.acs.ac_to_intra
 
-        Args:
-            device: GPU device ID to set the context to. If None, it will set the context to CPU if using a GPU backend, or do nothing if already using a CPU backend.
-        """
+    # --- routing / dispatch forwards ---
+    def unpack_indices(self, *args, **kwargs):
+        return self.acs.unpack_indices(*args, **kwargs)
 
-        if device is None or self.gpus is None:
-            # CPU context - set context to CPU if using a GPU backend, otherwise do nothing
-            with jax.default_device(jax.devices("cpu")[0]):
-                yield "cpu"
+    def unpack_coords(self, *args, **kwargs):
+        return self.acs.unpack_coords(*args, **kwargs)
 
-        else:
-            # device_id = self.gpus.index(device)
+    def place_on_device(self, *args, **kwargs):
+        return self.acs.place_on_device(*args, **kwargs)
 
-            # GPU context - set context to the specified GPU device
-            # with jax.default_device(jax.devices("gpu")[device_id]):
-            with self.xp.cuda.Device(device):
-                yield f"gpu: {device}"
+    def _loop_operation(self, *args, **kwargs):
+        return self.acs._loop_operation(*args, **kwargs)
 
-    def restore_main_device(self):
-        """Restores the main device context after GPU computations, and calls ``xp.get_default_memory_pool().free_all_blocks()`` to clear GPU memory.
-
-        Notes:
-            This method should be called after performing computations on multiple GPU devices to ensure that the main device context is restored.
-        """
-        if self.main_gpu is not None:
-            self.xp.get_default_memory_pool().free_all_blocks()
-            self.xp.cuda.runtime.setDevice(self.main_gpu)
-            jax.config.update(
-                "jax_default_device", jax.devices("gpu")[self.gpus.index(self.main_gpu)]
-            )
+    def device_context(self, *args, **kwargs):
+        return self.acs.device_context(*args, **kwargs)
 
     def synchronize(self):
-        """Synchronizes all GPU devices to ensure that all computations are complete before proceeding.
-
-        Notes:
-            This method should be called after performing computations on multiple GPU devices to ensure that all devices have completed their tasks before moving on to the next steps in the workflow.
-        """
-        if self.gpus is not None:
-            for device in self.gpus:
-                with self.device_context(device):
-                    self.xp.cuda.runtime.deviceSynchronize()
+        return self.acs.synchronize()
 
     def free_gpu_memory(self):
-        """Frees GPU memory on all devices by calling ``xp.get_default_memory_pool().free_all_blocks()`` for each device.
+        return self.acs.free_gpu_memory()
 
-        Notes:
-            This method should be called after performing computations on multiple GPU devices to ensure that GPU memory is freed and available for future computations.
-        """
-        if self.gpus is not None:
-            for device in self.gpus:
-                with self.device_context(device):
-                    self.xp.get_default_memory_pool().free_all_blocks()
+    def restore_main_device(self):
+        # Kept for API-compat; ACA restores device state inline (no-op here).
+        return None
 
-    def _to_host(self, arr: NDArrayLike) -> np.ndarray:
-        """Move an array to the host, ensuring it is a numpy ndarray."""
-        return arr.get() if hasattr(arr, "get") else arr
+    def _to_host(self, arr):
+        return self.acs._to_host(arr)
 
-    def unpack_indices(
-        self,
-        data_index: NDArrayLike,
-        noise_index: NDArrayLike = None,
-    ) -> tuple[list[np.ndarray], list[np.ndarray], list[np.ndarray]]:
-        """Partition a flat ``(data_index, noise_index)`` batch by split.
+    def compute_d_d_terms(self, *args, **kwargs):
+        return self.acs.compute_d_d_terms(*args, **kwargs)
 
-        Returns three parallel lists of length ``self.num_splits``:
+    def compute_noise_terms(self, *args, **kwargs):
+        return self.acs.compute_noise_terms(*args, **kwargs)
 
-        * ``positions_per_split[s]``: flat-batch positions routed to split ``s``
-          (empty arrays for splits with no matching ACs — callers skip
-          via ``len(positions) == 0``).
-        * ``data_intra_per_split[s]``: intra-split AC ids for those positions,
-          ready to be moved to device via ``self.xp.asarray``.
-        * ``noise_intra_per_split[s]``: intra-split noise AC ids.
+    def _compute_group_likelihood(self, *args, **kwargs):
+        return self.acs._compute_group_likelihood(*args, **kwargs)
 
-        This is the single owner of the partition — downstream routines
-        (waveform generation, likelihood scatter, residual dispatch) share
-        its output instead of recomputing ``np.where(ac_to_split == s)``.
-        """
-        data_index_cpu = self._to_host(data_index)
-        noise_index_cpu = self._to_host(noise_index) if noise_index is not None else data_index_cpu
+    def compute_signal_likelihood(self, *args, **kwargs):
+        return self.acs.compute_signal_likelihood(*args, **kwargs)
 
-        split_of_each = self.ac_to_split[data_index_cpu]
-
-        positions_per_split: list[np.ndarray] = []
-        data_intra_per_split: list[np.ndarray] = []
-        noise_intra_per_split: list[np.ndarray] = []
-        for split_id in range(self.num_splits):
-            positions = np.where(split_of_each == split_id)[0]
-            positions_per_split.append(positions)
-            data_intra_per_split.append(self.ac_to_intra[data_index_cpu[positions]])
-            noise_intra_per_split.append(self.ac_to_intra[noise_index_cpu[positions]])
-
-        return positions_per_split, data_intra_per_split, noise_intra_per_split
-
-    def unpack_coords(
-        self,
-        positions_per_split: list[np.ndarray],
-        coords: NDArrayLike | tuple[NDArrayLike],
-        keep_tuple: bool = False,
-    ) -> list[tuple[np.ndarray] | np.ndarray]:
-        """
-        Unpack coordinates for each split based on the positions per split.
-
-        Args:
-            positions_per_split: list of numpy arrays, where each array contains the positions for a specific split.
-            coords: A numpy or cupy array containing the coordinates to be unpacked, or a tuple of such arrays if there are multiple coordinate arrays (multiple branches).
-            keep_tuple: If True, ensure the returned coordinates per split are always in a tuple format. This applies only when there is a single coordinate array.
-
-        Returns:
-            args_per_group: A list of coordinates for each split, where each element is either a single array (if there is only one coordinate array) or a tuple of arrays (if there are multiple coordinate arrays). The coordinates are indexed according to the positions for each split.
-        """
-
-        if not isinstance(coords, tuple):
-            coords = (coords,)
-
-        coords_host = tuple(self._to_host(coords_here) for coords_here in coords)
-
-        args_per_group: list = []
-        for positions in positions_per_split:
-            if len(positions) > 0:
-                coords_s = [np.asfortranarray(coords_host[i][positions]) for i in range(len(coords_host))]
-
-                args_per_group.append(tuple(coords_s) if len(coords_s) > 1 or keep_tuple else coords_s[0])
-            else:
-                args_per_group.append(())
-
-        return args_per_group
-
-    def place_on_device(
-        self, items: tuple[list[np.ndarray | tuple[np.ndarray]]]
-    ) -> tuple[list[NDArrayLike | tuple[NDArrayLike]]]:
-        """Place lists of arrays on the appropriate devices for each split.
-
-        Args:
-            items: A tuple of lists of numpy arrays, where each entry in the tuple corresponds to a different type of array (e.g., data_index, noise_index, template_vals), and each list contains the arrays for each split.
-
-        Returns:
-            A tuple of lists of arrays, where each array has been moved to the appropriate device for its split using ``self.xp.asarray``.
-        """
-        num_items = len(items)
-
-        device_items: list[list] = [[] for _ in range(num_items)]
-
-        for i, device in enumerate(
-            self.gpus if self.gpus is not None else [None] * self.num_splits
-        ):
-            with self.device_context(device):
-                for item_id, item_per_split in enumerate(items):
-                    entry = item_per_split[i]
-                    if isinstance(entry, np.ndarray):
-                        device_items[item_id].append(self.xp.asarray(entry, copy=True))
-                    elif isinstance(entry, tuple):
-                        if len(entry) == 0:
-                            device_items[item_id].append(())
-                        else:
-                            device_items[item_id].append(tuple(self.xp.asarray(arr, copy=True) for arr in entry))
-                    else:
-                        raise ValueError("Each entry in items must be either a numpy array or a tuple of numpy arrays.")
-        return tuple(device_items)
-
-    def _loop_operation(
-        self,
-        operation: Callable | list[Callable],
-        operation_args_per_split: list[tuple] = None,
-        operation_kwargs: dict | list[dict] = None,
-        aggregate_fn: Callable = None,
-        positions_per_split: list[np.ndarray] = None,
-        run_threaded: bool = False,
-    ) -> list | Any:
-        """General loop to perform an operation across splits, with optional result aggregation.
-
-        Args:
-            operation: A callable or a list of callables (one per split) to execute within each split's device context. Each callable should accept the corresponding args and kwargs for that split.
-            operation_args_per_split: Optional list of tuples, where each tuple contains the positional arguments to pass to the operation for the corresponding split. The caller is responsible for ensuring that the arguments are correctly placed on the appropriate device (e.g., via self.xp.asarray). If not provided, defaults to a list of empty tuples.
-            operation_kwargs: Optional dictionary or list of dictionaries of keyword arguments to pass to the operation for all splits.
-            aggregate_fn: Optional callable to aggregate the results from all splits after the loop. If not provided, the raw list of results from each split is returned.
-            positions_per_split: Optional list of numpy arrays containing the positions for each split, used to guard against empty splits.
-            run_threaded: If True, dispatch operations across splits using a ThreadPoolExecutor. Default is False.
-        Returns:
-            A list of results from each split if aggregate_fn is not provided, or the aggregated result if aggregate_fn is provided.
-        """
-        if operation_args_per_split is None:
-            operation_args_per_split = [()] * self.num_splits
-        if operation_kwargs is None:
-            operation_kwargs = {}
-
-        if len(operation_args_per_split) != self.num_splits:
-            raise ValueError("Length of operation_args_per_split must match the number of splits.")
-
-        if isinstance(operation, list):
-            if len(operation) != self.num_splits:
-                raise ValueError(
-                    "If operation is a list, its length must match the number of splits."
-                )
-            operations = operation
-        else:
-            operations = [operation] * self.num_splits
-
-        if isinstance(operation_kwargs, list):
-            if len(operation_kwargs) != self.num_splits:
-                raise ValueError(
-                    "If operation_kwargs is a list, its length must match the number of splits."
-                )
-            operation_kwargs_per_split = operation_kwargs
-        else:
-            operation_kwargs_per_split = [operation_kwargs] * self.num_splits
-
-        devices = self.gpus if self.gpus is not None else [None] * self.num_splits
-
-        def _run_split_operation(i, device):
-            if positions_per_split is not None and len(positions_per_split[i]) == 0:
-                return None
-            with self.device_context(device):
-                return operations[i](*operation_args_per_split[i], **operation_kwargs_per_split[i])
-        
-        if run_threaded:
-            futures = [self.thread_pool.submit(_run_split_operation, i, device) for i, device in enumerate(devices)]
-            outputs = [future.result() for future in futures]
-        else:
-            outputs = []
-            for i, device in enumerate(
-                devices
-            ):
-                out_i = _run_split_operation(i, device)
-                outputs.append(out_i)
-
-        if aggregate_fn is not None:
-            return aggregate_fn(outputs)
-        return outputs
-
-    def compute_d_d_terms(self, out: bool = False, **kwargs):
-        """Compute (d|d) terms for all splits and store them in the respective computation groups."""
-
-        operations = [group.compute_d_d_term for group in self.computation_groups]
-
-        list_out = self._loop_operation(
-            operation=operations, operation_kwargs={"out": out, **kwargs}
-        )
-        if out:
-            return list_out
-
-    def compute_noise_terms(self, out: bool = False, **kwargs):
-        """Compute noise likelihood terms for all splits and store them in the respective computation groups."""
-
-        operations = [group.compute_noise_term for group in self.computation_groups]
-
-        list_out = self._loop_operation(
-            operation=operations, operation_kwargs={"out": out, **kwargs}
-        )
-        if out:
-            return list_out
-
-    def _compute_group_likelihood(
-        self,
-        positions_per_split: list[np.ndarray],
-        data_intra_per_split: list[NDArrayLike],
-        noise_intra_per_split: list[NDArrayLike],
-        operations: list[Callable],
-        likelihood_args_per_split: list[tuple],
-        likelihood_kwargs: dict | list[dict] = None, 
-        run_threaded: bool = False,
-    ):
-        """Compute likelihood for each split using the provided likelihood functions and arguments, and aggregate the results into a single output array."""
-        # todo I am assuming everything has been placed on the correct device. use self.place_on_device if not.
-
-        operation_args_per_split = []
-        for split_id in range(self.num_splits):
-            likelihood_args = likelihood_args_per_split[split_id]
-            args_i = (
-                data_intra_per_split[split_id],
-                noise_intra_per_split[split_id],
-                *(likelihood_args if likelihood_args is not None else ()),
-            )
-            operation_args_per_split.append(args_i)
-
-        all_logls = self._loop_operation(
-            operation=operations, operation_args_per_split=operation_args_per_split, operation_kwargs=likelihood_kwargs, positions_per_split=positions_per_split, run_threaded=run_threaded
-        )
-
-        # now synchronize
-        self.synchronize()
-        n_data = sum(len(p) for p in positions_per_split)
-    
-        output = np.full(n_data, -1e300, dtype=np.float64)
-        for split_id, positions in enumerate(positions_per_split):
-            if len(positions) > 0:
-                output[positions] = self._to_host(all_logls[split_id])
-
-        if np.any(output == -1e300):
-            logger.warning("Some positions were not filled in the output array. This may indicate an issue with the likelihood computation or aggregation.")
-        return output
-
-    def compute_psd_likelihood(
-        self,
-        positions_per_split: list[np.ndarray],
-        data_intra_per_split: list[NDArrayLike],
-        noise_intra_per_split: list[NDArrayLike],
-        likelihood_args_per_split: list[tuple],
-        likelihood_kwargs: dict | list[dict] = None,
-        run_threaded: bool = False,
-    ):
-        """Compute PSD likelihood for each split and aggregate results."""
-        operations = [group.compute_psd_likelihood for group in self.computation_groups]
-        return self._compute_group_likelihood(
-            positions_per_split,
-            data_intra_per_split,
-            noise_intra_per_split,
-            operations,
-            likelihood_args_per_split,
-            likelihood_kwargs=likelihood_kwargs,
-            run_threaded=run_threaded,
-        )
-
-    def compute_signal_likelihood(
-        self,
-        positions_per_split: list[np.ndarray],
-        data_intra_per_split: list[NDArrayLike],
-        noise_intra_per_split: list[NDArrayLike],
-        likelihood_args_per_split: list[tuple],
-        likelihood_kwargs: dict | list[dict] = None,
-        run_threaded: bool = False,
-    ):
-        """Compute signal likelihood for each split and aggregate results."""
-        operations = [group.compute_signal_likelihood for group in self.computation_groups]
-        return self._compute_group_likelihood(
-            positions_per_split,
-            data_intra_per_split,
-            noise_intra_per_split,
-            operations,
-            likelihood_args_per_split,
-            likelihood_kwargs=likelihood_kwargs,
-            run_threaded=run_threaded,
-        )
+    def compute_psd_likelihood(self, *args, **kwargs):
+        return self.acs.compute_psd_likelihood(*args, **kwargs)

--- a/src/lisatools/domaincomputation.py
+++ b/src/lisatools/domaincomputation.py
@@ -16,12 +16,11 @@ from .domains import FDSettings, STFTSettings, WDMSettings
 from .utils.parallelbase import LISAToolsParallelModule
 
 if TYPE_CHECKING:
-    # ``domains.py`` imports the computation-group classes from this
-    # module at module-top-level, so pulling ``STFTSettings`` /
-    # ``FDSettings`` in eagerly here creates a circular import. They're
-    # only needed for type hints and an ``isinstance`` check in
-    # ``DomainComputationGroupArray.domain_type`` — the latter does its
-    # own lazy import.
+    # The settings classes (``FDSettings`` / ``STFTSettings`` /
+    # ``WDMSettings``) are used for the per-domain ``isinstance`` dispatch
+    # in the ``*ComputationGroup`` strategy classes below, which each do
+    # their own lazy ``from .domains import ...`` inside the method that
+    # needs them (see ``STFT``/``FD``/``WDMComputationGroup``).
     import cupy as cp  # typing-only; runtime cupy use lives in call sites
 
     from .analysiscontainer import AnalysisContainer, AnalysisContainerArray

--- a/src/lisatools/domaincomputation.py
+++ b/src/lisatools/domaincomputation.py
@@ -4,12 +4,12 @@ likelihood computation of (d|h) and (h|h) inner products."""
 from __future__ import annotations
 
 import logging
+import warnings
 from collections.abc import Callable
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
 from concurrent.futures import ThreadPoolExecutor
-import jax
 import numpy as np
 
 from .domains import FDSettings, STFTSettings, WDMSettings
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class BaseDomainComputationGroup(LISAToolsParallelModule):
+class DomainKernelStrategy(LISAToolsParallelModule):
     """Wraps C++ DomainWrap for batched likelihood computation on the AnalysisContainerArray data.
 
     One instance per GPU split.  Holds references to the linearized arrays
@@ -145,7 +145,7 @@ class BaseDomainComputationGroup(LISAToolsParallelModule):
 
     def __repr__(self):
         split_index = getattr(self, "split_index", None)
-        return f"BaseDomainComputationGroup with split index {split_index} and TDI type {self.tdi_type}"
+        return f"DomainKernelStrategy with split index {split_index} and TDI type {self.tdi_type}"
 
     @property
     def xp(self) -> ArrayModule:
@@ -336,7 +336,14 @@ class BaseDomainComputationGroup(LISAToolsParallelModule):
         return self.sensitivity_backend.compute_log_like(self.data_arr, data_index, *args, **kwargs)
 
 
-class STFTComputationGroup(BaseDomainComputationGroup):
+# Back-compat alias: the per-split strategy was renamed from
+# ``BaseDomainComputationGroup`` to :class:`DomainKernelStrategy` when the
+# array-level coordinator was absorbed into ``AnalysisContainerArray``.
+# Downstream code and tests subclass the old name — keep it working.
+BaseDomainComputationGroup = DomainKernelStrategy
+
+
+class STFTComputationGroup(DomainKernelStrategy):
     """Wraps C++ STFTDomainWrap for batched likelihood computation."""
 
     def __init__(
@@ -459,7 +466,7 @@ class STFTComputationGroup(BaseDomainComputationGroup):
         return d_h_out, h_h_out
 
 
-class FDComputationGroup(BaseDomainComputationGroup):
+class FDComputationGroup(DomainKernelStrategy):
     """
     Wraps C++ FDDomainWrap for batched likelihood computation.
     """
@@ -543,7 +550,7 @@ class FDComputationGroup(BaseDomainComputationGroup):
         return d_h_out, h_h_out
 
 
-class WDMComputationGroup(BaseDomainComputationGroup):
+class WDMComputationGroup(DomainKernelStrategy):
     """Wraps C++ WDMDomainWrap for batched likelihood computation (WDM).
 
     WDM counterpart of :class:`STFTComputationGroup` (2026-06 merge
@@ -699,28 +706,39 @@ class WDMComputationGroup(BaseDomainComputationGroup):
 
 
 class DomainComputationGroupArray:
-    """Thin forwarding shim over :class:`AnalysisContainerArray` (deprecated).
+    """Deprecated thin alias over :class:`AnalysisContainerArray`.
 
     The multi-split C++ likelihood coordinator was absorbed into
-    ``AnalysisContainerArray``: it now owns the per-split strategy workspaces
-    (``acs.cpp_splits`` — the STFT/FD/WDM ``*ComputationGroup`` objects) and the
-    batched orchestration directly. This shim forwards every attribute/method to
-    its ``acs`` so existing callers (global-fit moves, external settings files)
-    keep working during the migration.
+    ``AnalysisContainerArray``, which now owns the per-split strategy
+    workspaces (``acs.cpp_splits`` — the STFT/FD/WDM ``*ComputationGroup``
+    objects) and the batched orchestration directly. Drive the ACA methods
+    instead: ``acs.cpp_template_likelihood`` / ``acs.compute_signal_likelihood``
+    / ``acs.compute_psd_likelihood`` / ``acs.cpp_splits``.
 
-    Prefer the ACA methods directly: ``acs.cpp_template_likelihood`` /
-    ``acs.compute_signal_likelihood`` / ``acs.compute_psd_likelihood`` /
-    ``acs.cpp_splits``.
+    This alias is kept only so external settings files that still construct
+    ``DomainComputationGroupArray(acs=acs)`` and hand it to the global-fit
+    moves keep working — the moves resolve ``dcga.acs`` at their constructor
+    boundary. Constructing it directly emits a :class:`DeprecationWarning`;
+    the ACA's own :attr:`~AnalysisContainerArray.cpp_likelihood_backend`
+    compat handle builds it with ``_internal=True`` and stays quiet.
     """
 
-    def __init__(self, acs, domain_group_kwargs=None):
+    def __init__(self, acs, domain_group_kwargs=None, *, _internal=False):
+        if not _internal:
+            warnings.warn(
+                "DomainComputationGroupArray is deprecated: the C++ likelihood "
+                "coordinator now lives on AnalysisContainerArray. Pass the ACA "
+                "to the global-fit moves and use acs.cpp_template_likelihood / "
+                "acs.cpp_splits directly.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.acs = acs
         if domain_group_kwargs is not None:
             # Resets the strategy cache + stores the new kwargs.
             acs.domain_group_kwargs = domain_group_kwargs
         acs._ensure_cpp_splits()
 
-    # --- state forwards ---
     @property
     def computation_groups(self):
         return self.acs.cpp_splits
@@ -730,69 +748,9 @@ class DomainComputationGroupArray:
         return self.acs.gpus
 
     @property
-    def xp(self):
-        return self.acs.xp
-
-    @property
     def num_splits(self):
         return self.acs.num_splits
 
     @property
-    def main_gpu(self):
-        return self.acs.gpus[0] if self.acs.gpus is not None else None
-
-    @property
-    def thread_pool(self):
-        return self.acs.thread_pool
-
-    @property
-    def ac_to_split(self):
-        return self.acs.ac_to_split
-
-    @property
-    def ac_to_intra(self):
-        return self.acs.ac_to_intra
-
-    # --- routing / dispatch forwards ---
-    def unpack_indices(self, *args, **kwargs):
-        return self.acs.unpack_indices(*args, **kwargs)
-
-    def unpack_coords(self, *args, **kwargs):
-        return self.acs.unpack_coords(*args, **kwargs)
-
-    def place_on_device(self, *args, **kwargs):
-        return self.acs.place_on_device(*args, **kwargs)
-
-    def _loop_operation(self, *args, **kwargs):
-        return self.acs._loop_operation(*args, **kwargs)
-
-    def device_context(self, *args, **kwargs):
-        return self.acs.device_context(*args, **kwargs)
-
-    def synchronize(self):
-        return self.acs.synchronize()
-
-    def free_gpu_memory(self):
-        return self.acs.free_gpu_memory()
-
-    def restore_main_device(self):
-        # Kept for API-compat; ACA restores device state inline (no-op here).
-        return None
-
-    def _to_host(self, arr):
-        return self.acs._to_host(arr)
-
-    def compute_d_d_terms(self, *args, **kwargs):
-        return self.acs.compute_d_d_terms(*args, **kwargs)
-
-    def compute_noise_terms(self, *args, **kwargs):
-        return self.acs.compute_noise_terms(*args, **kwargs)
-
-    def _compute_group_likelihood(self, *args, **kwargs):
-        return self.acs._compute_group_likelihood(*args, **kwargs)
-
-    def compute_signal_likelihood(self, *args, **kwargs):
-        return self.acs.compute_signal_likelihood(*args, **kwargs)
-
-    def compute_psd_likelihood(self, *args, **kwargs):
-        return self.acs.compute_psd_likelihood(*args, **kwargs)
+    def xp(self):
+        return self.acs.xp

--- a/src/lisatools/domaincomputation.py
+++ b/src/lisatools/domaincomputation.py
@@ -712,8 +712,8 @@ class DomainComputationGroupArray:
     ``AnalysisContainerArray``, which now owns the per-split strategy
     workspaces (``acs.cpp_splits`` — the STFT/FD/WDM ``*ComputationGroup``
     objects) and the batched orchestration directly. Drive the ACA methods
-    instead: ``acs.cpp_template_likelihood`` / ``acs.compute_signal_likelihood``
-    / ``acs.compute_psd_likelihood`` / ``acs.cpp_splits``.
+    instead: ``acs.cpp_template_likelihood`` / ``acs.cpp_signal_likelihood``
+    / ``acs.cpp_psd_likelihood`` / ``acs.cpp_splits``.
 
     This alias is kept only so external settings files that still construct
     ``DomainComputationGroupArray(acs=acs)`` and hand it to the global-fit

--- a/src/lisatools/globalfit/moves/addremovemove.py
+++ b/src/lisatools/globalfit/moves/addremovemove.py
@@ -733,7 +733,7 @@ class MultiGPUResidualAddRemoveMove(ResidualAddOneRemoveOneMove, MultiGPUMoveBas
     Wrapper around ResidualAddOneRemoveOneMove that runs the waveform generation and likelihood computation on multiple GPUs.
 
     Args:
-    dcga: DomainComputationGroupArray that contains the information about the domain computation groups and the GPUs to use for each group.
+    dcga: the C++ likelihood coordinator carrying the per-split strategies and per-split GPU assignment. Accepts an AnalysisContainerArray (resolved via ``dcga.acs``) or a deprecated DomainComputationGroupArray shim wrapping one.
     waveform_gen: waveform generator class that generates the waveforms for the sources given their coordinates.
     branch_name: name of the branch that this move will operate on.
     coords_shape: shape of the coordinates of the sources in the branch that this move will operate on.

--- a/src/lisatools/globalfit/moves/addremovemove.py
+++ b/src/lisatools/globalfit/moves/addremovemove.py
@@ -936,7 +936,7 @@ class MultiGPUResidualAddRemoveMove(ResidualAddOneRemoveOneMove, MultiGPUMoveBas
         if not self.run_async:
             self.acs.synchronize()
 
-        likelihoods = self.acs.compute_signal_likelihood(
+        likelihoods = self.acs.cpp_signal_likelihood(
             positions_per_split=positions_per_split,
             data_intra_per_split=data_intra_index_per_split,
             noise_intra_per_split=data_intra_index_per_split,

--- a/src/lisatools/globalfit/moves/addremovemove.py
+++ b/src/lisatools/globalfit/moves/addremovemove.py
@@ -808,26 +808,26 @@ class MultiGPUResidualAddRemoveMove(ResidualAddOneRemoveOneMove, MultiGPUMoveBas
 
         self._waveform_generators = []
         for i, device in enumerate(
-            self.dcga.gpus if self.dcga.gpus is not None else [None] * self.dcga.num_splits
+            self.acs.gpus if self.acs.gpus is not None else [None] * self.acs.num_splits
         ):
             if not hasattr(self.waveform_gen, "kwargs"):
                 raise ValueError("Waveform generator must have a 'kwargs' attribute that contains the keyword arguments to initialize the waveform generator.")    
             
-            with self.dcga.device_context(device):
+            with self.acs.device_context(device):
                 # if i == 0:
                 #     # Reuse the initial waveform generator for the first split to save memory
                 #     self._waveform_generators.append(self.waveform_gen)
                 # else:
                 init_kwargs = self.waveform_gen.kwargs.copy()
                 if "orbits" in init_kwargs:
-                    init_kwargs["orbits"] = self.dcga.computation_groups[i].orbits
+                    init_kwargs["orbits"] = self.acs.cpp_split(i).orbits
 
                 self._waveform_generators.append(
                     self.waveform_gen.__class__(**init_kwargs)
                 )
 
     def free_gpu_memory(self):
-        self.dcga.free_gpu_memory()
+        self.acs.free_gpu_memory()
 
     @property
     def waveform_generators(self) -> list:
@@ -845,15 +845,15 @@ class MultiGPUResidualAddRemoveMove(ResidualAddOneRemoveOneMove, MultiGPUMoveBas
         Prepare the inputs for the waveform generator from the given coordinates and data index.
         """
 
-        positions_per_split, data_intra_index_per_split, _ = self.dcga.unpack_indices(data_index)
-        coords_per_split = self.dcga.unpack_coords(positions_per_split, coords, keep_tuple=True)
+        positions_per_split, data_intra_index_per_split, _ = self.acs.unpack_indices(data_index)
+        coords_per_split = self.acs.unpack_coords(positions_per_split, coords, keep_tuple=True)
 
-        data_intra_index_per_split, coords_per_split = self.dcga.place_on_device(
+        data_intra_index_per_split, coords_per_split = self.acs.place_on_device(
             items=(data_intra_index_per_split, coords_per_split)
         )
 
-        waveform_args_per_split = self.dcga._loop_operation(
-            operation=[self.make_args_tuple for _ in self.dcga.computation_groups],
+        waveform_args_per_split = self.acs._loop_operation(
+            operation=[self.make_args_tuple for _ in self.acs.cpp_splits],
             operation_args_per_split=coords_per_split,
         )
 
@@ -890,7 +890,7 @@ class MultiGPUResidualAddRemoveMove(ResidualAddOneRemoveOneMove, MultiGPUMoveBas
 
         operations = [getattr(waveform_gen, self.waveform_gen_method) for waveform_gen in self.waveform_generators]
 
-        waveforms_out = self.dcga._loop_operation(
+        waveforms_out = self.acs._loop_operation(
             operation=operations,
             operation_args_per_split=waveform_args_per_split,
             operation_kwargs=self.waveform_gen_kwargs,
@@ -898,7 +898,7 @@ class MultiGPUResidualAddRemoveMove(ResidualAddOneRemoveOneMove, MultiGPUMoveBas
             run_threaded=self.run_threaded,
         )
 
-        self.dcga.synchronize()
+        self.acs.synchronize()
 
         return waveforms_out
 
@@ -907,7 +907,7 @@ class MultiGPUResidualAddRemoveMove(ResidualAddOneRemoveOneMove, MultiGPUMoveBas
         Set up the likelihood computation. In the general case, this means computing the :math:\\langle d | d \\rangle term.
         """
 
-        self.dcga.compute_d_d_terms()
+        self.acs.compute_d_d_terms()
 
     def compute_like(self, coords_in: np.ndarray, data_index: np.ndarray) -> np.ndarray:
         """
@@ -925,7 +925,7 @@ class MultiGPUResidualAddRemoveMove(ResidualAddOneRemoveOneMove, MultiGPUMoveBas
 
         waveform_like_operations = [getattr(waveform_gen, self.waveform_like_method) for waveform_gen in self.waveform_generators]
 
-        likelihood_args_per_split = self.dcga._loop_operation(
+        likelihood_args_per_split = self.acs._loop_operation(
             operation=waveform_like_operations,
             operation_args_per_split=waveform_args_per_split,
             operation_kwargs=self.waveform_like_kwargs,
@@ -934,9 +934,9 @@ class MultiGPUResidualAddRemoveMove(ResidualAddOneRemoveOneMove, MultiGPUMoveBas
         ) 
 
         if not self.run_async:
-            self.dcga.synchronize()
+            self.acs.synchronize()
 
-        likelihoods = self.dcga.compute_signal_likelihood(
+        likelihoods = self.acs.compute_signal_likelihood(
             positions_per_split=positions_per_split,
             data_intra_per_split=data_intra_index_per_split,
             noise_intra_per_split=data_intra_index_per_split,

--- a/src/lisatools/globalfit/moves/mbhspecialmove.py
+++ b/src/lisatools/globalfit/moves/mbhspecialmove.py
@@ -177,13 +177,13 @@ class TDMBHSpecialMove(MultiGPUResidualAddRemoveMove):
             all_inds = np.tile(np.arange(self.nwalkers), (self.ntemps, 1))
             inds = all_inds % self.nsplits
             if self.randomize_split:
-                if self.dcga.gpus is None:
+                if self.acs.gpus is None:
                     [np.random.shuffle(x) for x in inds]
                 
                 else:
-                    num_per_gpu = self.nwalkers // len(self.dcga.gpus)
+                    num_per_gpu = self.nwalkers // len(self.acs.gpus)
                     for row in inds:
-                        for gpu in self.dcga.gpus:
+                        for gpu in self.acs.gpus:
                             start = gpu * num_per_gpu
                             end = (gpu + 1) * num_per_gpu
                             np.random.shuffle(row[start:end])

--- a/src/lisatools/globalfit/moves/multigpumove.py
+++ b/src/lisatools/globalfit/moves/multigpumove.py
@@ -16,15 +16,26 @@ logger = getLogger(__name__)
 
 
 class MultiGPUMoveBase:
-    def __init__(self, dcga: DomainComputationGroupArray, run_async: bool = False, run_threaded: bool = False):
-        self._dcga = dcga
+    def __init__(self, dcga: DomainComputationGroupArray = None, run_async: bool = False, run_threaded: bool = False, *, acs=None):
+        # The C++ likelihood coordinator now lives on ``AnalysisContainerArray``
+        # (DCGA was absorbed). Accept either an ACA or a (deprecated)
+        # ``DomainComputationGroupArray`` shim at the constructor boundary so
+        # external settings files that still pass ``dcga=`` keep working, and
+        # resolve both to the real ACA. We no longer store the DCGA itself.
+        resolved = acs if acs is not None else dcga
+        self.acs = resolved.acs if hasattr(resolved, "acs") else resolved
         self._run_async = run_async
         self._run_threaded = run_threaded
 
     @property
     def dcga(self) -> DomainComputationGroupArray:
-        return self._dcga
-    
+        """Transitional handle to the ACA-owned cpp coordinator shim.
+
+        Forwards to ``self.acs``; removed in Phase C once every move drives the
+        ACA directly via ``self.acs``.
+        """
+        return self.acs.cpp_likelihood_backend
+
     @property
     def run_async(self) -> bool:
         return self._run_async
@@ -35,5 +46,5 @@ class MultiGPUMoveBase:
 
     @property
     def xp(self):
-        """Return the array library (numpy or cupy) used by the DomainComputationGroupArray."""
-        return self.dcga.xp
+        """Return the array library (numpy or cupy) used by the analysis container array."""
+        return self.acs.xp

--- a/src/lisatools/globalfit/moves/multigpumove.py
+++ b/src/lisatools/globalfit/moves/multigpumove.py
@@ -28,15 +28,6 @@ class MultiGPUMoveBase:
         self._run_threaded = run_threaded
 
     @property
-    def dcga(self) -> DomainComputationGroupArray:
-        """Transitional handle to the ACA-owned cpp coordinator shim.
-
-        Forwards to ``self.acs``; removed in Phase C once every move drives the
-        ACA directly via ``self.acs``.
-        """
-        return self.acs.cpp_likelihood_backend
-
-    @property
     def run_async(self) -> bool:
         return self._run_async
 

--- a/src/lisatools/globalfit/moves/psdmove.py
+++ b/src/lisatools/globalfit/moves/psdmove.py
@@ -656,7 +656,7 @@ class MultiGPUPSDMove(PSDMove, MultiGPUMoveBase):
             positions_per_split=positions_per_split,
         )
 
-        ll = self.acs.compute_psd_likelihood(
+        ll = self.acs.cpp_psd_likelihood(
             positions_per_split,
             data_intra_index_per_split,
             data_intra_index_per_split,

--- a/src/lisatools/globalfit/moves/psdmove.py
+++ b/src/lisatools/globalfit/moves/psdmove.py
@@ -588,15 +588,21 @@ class MultiGPUPSDMove(PSDMove, MultiGPUMoveBase):
         **kwargs,
     ):
 
+        # Resolve the real ACA (tolerate an ACA or a deprecated DCGA shim at the
+        # constructor boundary) and ensure its per-split cpp strategies exist so
+        # split 0's sensitivity backend is available below.
+        acs = dcga.acs if hasattr(dcga, "acs") else dcga
+        acs._ensure_cpp_splits()
+
         PSDMove.__init__(
             self,
-            dcga.acs,
+            acs,
             priors,
             *args,
             num_repeats=num_repeats,
             max_logl_mode=max_logl_mode,
             psd_kwargs=psd_kwargs,
-            sensitivity_backend=dcga.computation_groups[0].sensitivity_backend,
+            sensitivity_backend=acs.cpp_split(0).sensitivity_backend,
             psd_transform_fn=psd_transform_fn,
             galfor_transform_fn=galfor_transform_fn,
             permute_every=permute_every,
@@ -618,7 +624,7 @@ class MultiGPUPSDMove(PSDMove, MultiGPUMoveBase):
     def allowed_shards(self) -> int:
         """Number of shards allowed for the kernel fast path. In the multi-GPU case, this is equal to the number of devices."""
     
-        return len(self.dcga.computation_groups)
+        return self.acs.num_splits
 
     def psd_log_like(self, x: list, supps=None, **sens_kwargs):
         """ """
@@ -637,20 +643,20 @@ class MultiGPUPSDMove(PSDMove, MultiGPUMoveBase):
 
         data_index_all = np.asarray(wi).astype(np.int32)
 
-        positions_per_split, data_intra_index_per_split, _ = self.dcga.unpack_indices(data_index_all)
-        coords_per_split = self.dcga.unpack_coords(positions_per_split, (psd_pars, galfor_pars))
+        positions_per_split, data_intra_index_per_split, _ = self.acs.unpack_indices(data_index_all)
+        coords_per_split = self.acs.unpack_coords(positions_per_split, (psd_pars, galfor_pars))
 
-        data_intra_index_per_split, coords_per_split = self.dcga.place_on_device(
+        data_intra_index_per_split, coords_per_split = self.acs.place_on_device(
             items=(data_intra_index_per_split, coords_per_split)
         )
 
-        likelihood_args_per_split = self.dcga._loop_operation(
+        likelihood_args_per_split = self.acs._loop_operation(
             operation=self.prepare_likelihood_inputs,
             operation_args_per_split=coords_per_split,
             positions_per_split=positions_per_split,
         )
 
-        ll = self.dcga.compute_psd_likelihood(
+        ll = self.acs.compute_psd_likelihood(
             positions_per_split,
             data_intra_index_per_split,
             data_intra_index_per_split,
@@ -676,5 +682,5 @@ class MultiGPUPSDMove(PSDMove, MultiGPUMoveBase):
                 )
             ll[invalid_knots_mask] = -1e300
 
-        self.dcga.free_gpu_memory()
+        self.acs.free_gpu_memory()
         return ll

--- a/src/lisatools/globalfit/moves/psdmove.py
+++ b/src/lisatools/globalfit/moves/psdmove.py
@@ -567,7 +567,7 @@ class PSDMove(GlobalFitMove, StretchMove):
 
 
 # stft_tof addition: multi-GPU variant of the PSD move running the kernel
-# fast path through DomainComputationGroupArray's per-device replicas. Kept
+# fast path through the ACA's per-split C++ likelihood coordinator. Kept
 # through the merge; its interaction with the dev-side ACA sharding is
 # reviewed in the dedicated multi-GPU pass.
 class MultiGPUPSDMove(PSDMove, MultiGPUMoveBase):
@@ -612,12 +612,13 @@ class MultiGPUPSDMove(PSDMove, MultiGPUMoveBase):
         MultiGPUMoveBase.__init__(self, dcga, run_async=run_async, run_threaded=run_threaded)
 
         # TEST FLAG: when True, MultiGPUPSDMove.psd_log_like delegates to the
-        # parent PSDMove.psd_log_like, completely bypassing DCGA's unpack/place/
-        # loop_operation machinery. Only meaningful on single-GPU setups.
-        # If flipping this to True makes CHECK1/CHECK2 stop firing, the bug is
-        # localized to the DCGA path (unpack_coords/place_on_device/
-        # _loop_operation/_compute_group_likelihood). Set from the settings
-        # file via `psd_move._force_parent_path = True` after move construction.
+        # parent PSDMove.psd_log_like, completely bypassing the ACA cpp
+        # coordinator's unpack/place/loop_operation machinery. Only meaningful
+        # on single-GPU setups. If flipping this to True makes CHECK1/CHECK2
+        # stop firing, the bug is localized to the ACA cpp coordinator path
+        # (unpack_coords/place_on_device/_loop_operation/_compute_group_likelihood).
+        # Set from the settings file via `psd_move._force_parent_path = True`
+        # after move construction.
         self._force_parent_path = False
 
     @property
@@ -631,9 +632,10 @@ class MultiGPUPSDMove(PSDMove, MultiGPUMoveBase):
         if supps is None:
             raise ValueError("Must provide supps to identify the data streams.")
 
-        # Single-GPU debug path: skip DCGA entirely and run the parent's direct
-        # sensitivity_backend.compute_log_like call. This isolates whether the
-        # bug is in the MultiGPU routing (DCGA unpack/place/loop) or elsewhere.
+        # Single-GPU debug path: skip the ACA cpp coordinator entirely and run
+        # the parent's direct sensitivity_backend.compute_log_like call. This
+        # isolates whether the bug is in the MultiGPU routing (ACA
+        # unpack/place/loop) or elsewhere.
         if getattr(self, "_force_parent_path", False):
             return PSDMove.psd_log_like(self, x, supps=supps, **sens_kwargs)
 

--- a/tests/test_aca_cpp_likelihood_backend.py
+++ b/tests/test_aca_cpp_likelihood_backend.py
@@ -1,0 +1,519 @@
+"""Tests for the ACA-owned C++ likelihood backend + forwarder.
+
+Covers the additive integration in :class:`AnalysisContainerArray`:
+
+* the lazily-built, owned :class:`DomainComputationGroupArray`
+  (:attr:`cpp_likelihood_backend` / :attr:`domain_computation_group`,
+  configured via :attr:`domain_group_kwargs`);
+* the :meth:`AnalysisContainerArray.cpp_template_likelihood` forwarder
+  that drives the multi-split propagation through the owned backend; and
+* :meth:`refresh_cpp_dd` for the cached ``(d|d)`` term.
+
+The forwarder is pure plumbing over the DCGA primitives
+(``unpack_indices`` / ``unpack_coords`` / ``place_on_device`` /
+``compute_signal_likelihood``), all already covered by
+``test_multi_gpu_placement.py``. Here we exercise the *forwarder* code path
+itself, two ways:
+
+* **WDM** (:class:`TestWDMForwarderRealKernel`) drives the **real C++ WDM
+  likelihood kernel** (``WDMDomainWrap``) — the lazily-built real
+  ``WDMComputationGroup`` runs on CPU. This validates the forwarder feeding a
+  genuine kernel end-to-end, including the lazy backend build.
+* **FD** (:class:`TestFDForwarderStubGroup`) drives a NumPy stub group (the
+  established pattern from ``test_multi_gpu_placement.py``; the merged real
+  ``FDComputationGroup`` requires the not-yet-reconciled STFT-era FD binding).
+  This covers the complex-dtype + ``start_times=None`` forwarder path.
+
+STFT shares the identical forwarder code path (the forwarder treats the
+template opaquely — it only coerces dtype and scatters); WDM (4-index
+sub-grids, real) and FD (3-index, complex) together exercise the shape and
+dtype generality.
+
+We drive the *real* ``AnalysisContainerArray`` methods (borrowed onto a
+lightweight ACS host that carries exactly the attributes the backend reads),
+so the code under test is the production forwarder, not a re-implementation.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from lisatools.analysiscontainer import AnalysisContainerArray as _ACA
+from lisatools.domaincomputation import (
+    BaseDomainComputationGroup,
+    DomainComputationGroupArray,
+)
+from lisatools.domains import FDSettings, WDMSettings
+
+
+# ---------------------------------------------------------------------------
+# Re-instantiable stub sensitivity / orbits / AC (mirrors test_multi_gpu_placement).
+# build_cpp_objects rebuilds orbits + sensitivity per split via the
+# ``args`` / ``kwargs`` reconstruction protocol; the stubs satisfy exactly
+# that, with no C++ sensitivity objects touched. The per-AC ``inner_product``
+# returns the precomputed (d|d) so the cached term is deterministic.
+# ---------------------------------------------------------------------------
+
+
+class _StubOrbits:
+    def __init__(self):
+        self.args = ()
+        self.kwargs = {}
+
+
+class _StubSensMat:
+    def __init__(self, orbits=None):
+        self.orbits = orbits if orbits is not None else _StubOrbits()
+        self.kwargs = {"orbits": self.orbits}
+
+
+class _StubAC:
+    def __init__(self, d_d_value: float):
+        self._d_d = float(d_d_value)
+        self.sens_mat = _StubSensMat()
+
+    def inner_product(self, **_):
+        return self._d_d
+
+
+class _ACSHost:
+    """A stub ``AnalysisContainerArray`` that *borrows* the real forwarder.
+
+    Carries every attribute the owned ``DomainComputationGroupArray`` reads
+    (``settings`` / ``gpus`` / ``xp`` / ``acs_total_entries`` /
+    ``gpu_splits`` / ``split_map`` / ``linear_data_arr`` / ``linear_psd_arr``
+    / ``nchannels`` / ``acs``), plus the ``xp`` / ``data_dtype`` /
+    ``run_threaded`` the forwarder reads, and the lazy-state attributes. The
+    forwarder + accessors are the genuine ``AnalysisContainerArray``
+    implementations, assigned here so the test exercises production code.
+    """
+
+    # --- borrowed, under test ---
+    cpp_template_likelihood = _ACA.cpp_template_likelihood
+    refresh_cpp_dd = _ACA.refresh_cpp_dd
+    cpp_likelihood_backend = _ACA.cpp_likelihood_backend  # property
+    domain_computation_group = _ACA.domain_computation_group  # property
+    domain_group_kwargs = _ACA.domain_group_kwargs  # property (+ setter)
+
+    xp = np
+    run_threaded = False
+
+    def __init__(
+        self,
+        settings,
+        data,
+        invC,
+        d_d_values,
+        nchannels,
+        num_splits,
+        data_dtype,
+        domain_group_kwargs=None,
+    ):
+        num_acs = data.shape[0]
+        if num_acs % num_splits:
+            raise ValueError("num_acs must be divisible by num_splits.")
+
+        self.settings = settings
+        self.gpus = None
+        self.nchannels = nchannels
+        self.acs_total_entries = int(num_acs)
+        self.data_dtype = data_dtype
+
+        split_num = int(np.ceil(num_acs / num_splits))
+        split_inds = np.arange(split_num, num_acs, split_num)
+        self.gpu_splits = np.split(np.arange(num_acs), split_inds)
+        assert len(self.gpu_splits) == num_splits
+        self.split_map = np.zeros(num_acs, dtype=int)
+        for split_id, entries in enumerate(self.gpu_splits):
+            self.split_map[entries] = split_id
+
+        self.linear_data_arr = [
+            np.concatenate([data[i].ravel() for i in entries])
+            for entries in self.gpu_splits
+        ]
+        self.linear_psd_arr = [
+            np.concatenate([invC[i].ravel() for i in entries])
+            for entries in self.gpu_splits
+        ]
+        self.acs = np.asarray([_StubAC(v) for v in d_d_values], dtype=object)
+
+        # Lazy-state attributes the borrowed accessors read/write.
+        self._domain_group_kwargs = dict(domain_group_kwargs or {})
+        self._cpp_likelihood_backend = None
+
+
+# ---------------------------------------------------------------------------
+# FD stub group + coordinator (NumPy XYZ reference), from test_multi_gpu_placement.
+# ---------------------------------------------------------------------------
+
+
+def _cross_inner(a, b, invC, df):
+    """``<a|b> = 4 df sum_{i,j,f} conj(a[i,f]) invC[i,j,f] b[j,f]`` (XYZ FD)."""
+    nch = a.shape[0]
+    acc = 0.0 + 0.0j
+    for i in range(nch):
+        for j in range(nch):
+            acc += np.sum(np.conj(a[i]) * invC[i, j] * b[j])
+    return 4.0 * df * acc
+
+
+class _StubFDComputationGroup(BaseDomainComputationGroup):
+    """NumPy stand-in for ``FDComputationGroup`` (XYZ full-cov reference)."""
+
+    def compute_signal_likelihood_terms(
+        self, data_index, noise_index, template_vals, start_freqs, start_times=None, **_
+    ):
+        nb, nch, nfreq = template_vals.shape
+        data = self.data_arr.reshape(self.num_data, nch, nfreq)
+        invC = self.invC_arr.reshape(self.num_noise, nch, nch, nfreq)
+        df = self.settings.df
+        d_h = np.zeros(nb, dtype=np.complex128)
+        h_h = np.zeros(nb, dtype=np.complex128)
+        for b in range(nb):
+            d = data[int(data_index[b])]
+            ic = invC[int(noise_index[b])]
+            h = template_vals[b]
+            d_h[b] = _cross_inner(d, h, ic, df)
+            h_h[b] = _cross_inner(h, h, ic, df)
+        return d_h, h_h
+
+
+class _StubFDDCGA(DomainComputationGroupArray):
+    @property
+    def computation_group_class(self):
+        return _StubFDComputationGroup
+
+
+# ---------------------------------------------------------------------------
+# WDM: real C++ kernel through the forwarder (lazy backend build).
+# ---------------------------------------------------------------------------
+
+
+class TestWDMForwarderRealKernel(unittest.TestCase):
+    """``AnalysisContainerArray.cpp_template_likelihood`` against the real
+    WDM kernel, exercising the lazy backend build + multi-split propagation."""
+
+    Nf, Nt, dt = 32, 64, 5.0
+    IMN_F, IMX_F, IMN_T, IMX_T = 3, 20, 4, 50
+    NCH = 3
+    N_M, N_N = 4, 8
+
+    @classmethod
+    def setUpClass(cls):
+        cls.layer_df = 1.0 / (2 * cls.Nf * cls.dt)
+        cls.layer_dt = cls.Nf * cls.dt
+        cls.Nf_a = cls.IMX_F - cls.IMN_F + 1
+        cls.Nt_a = cls.IMX_T - cls.IMN_T + 1
+
+    def _settings(self):
+        # Half-pixel margins so the index setters land exactly on target.
+        return WDMSettings(
+            self.Nf, self.Nt, self.dt,
+            min_freq=(self.IMN_F - 0.5) * self.layer_df,
+            max_freq=(self.IMX_F + 0.5) * self.layer_df,
+            min_time=(self.IMN_T - 0.5) * self.layer_dt,
+            max_time=(self.IMX_T + 0.5) * self.layer_dt,
+        )
+
+    def _make_data(self, num_acs, seed):
+        rng = np.random.default_rng(seed)
+        data = rng.standard_normal((num_acs, self.NCH, self.Nf_a, self.Nt_a))
+        invC = rng.uniform(0.5, 2.0, (num_acs, self.NCH, self.Nf_a, self.Nt_a))
+        d_d = np.array([4 * 0.25 * np.sum(data[i] ** 2 * invC[i]) for i in range(num_acs)])
+        return data, invC, d_d
+
+    def _make_host(self, num_acs, num_splits, seed=0):
+        data, invC, d_d = self._make_data(num_acs, seed)
+        host = _ACSHost(
+            self._settings(), data, invC, d_d,
+            nchannels=self.NCH, num_splits=num_splits, data_dtype=float,
+            domain_group_kwargs={"tdi_type": "AET"},
+        )
+        host._raw = (data, invC, d_d)  # for references
+        return host
+
+    def _make_batch(self, num_acs, nb, seed=7):
+        rng = np.random.default_rng(seed)
+        data_index = np.tile(np.arange(num_acs), int(np.ceil(nb / num_acs)))[:nb].astype(np.int32)
+        start_m = rng.integers(self.IMN_F, self.IMX_F - self.N_M + 2, nb)
+        start_n = rng.integers(self.IMN_T, self.IMX_T - self.N_N + 2, nb)
+        templ = rng.standard_normal((nb, self.NCH, self.N_M, self.N_N))
+        start_freqs = (start_m * self.layer_df).astype(np.float64)
+        start_times = (start_n * self.layer_dt).astype(np.float64)
+        return data_index, templ, start_freqs, start_times, start_m, start_n
+
+    def _reference(self, host, data_index, templ, start_m, start_n):
+        data, invC, d_d = host._raw
+        nb = data_index.shape[0]
+        out = np.zeros(nb)
+        for b in range(nb):
+            sl_m = slice(start_m[b] - self.IMN_F, start_m[b] - self.IMN_F + self.N_M)
+            sl_n = slice(start_n[b] - self.IMN_T, start_n[b] - self.IMN_T + self.N_N)
+            d_sub = data[data_index[b]][:, sl_m, sl_n]
+            w_sub = invC[data_index[b]][:, sl_m, sl_n]
+            h = templ[b]
+            d_h = 4 * 0.25 * np.sum(d_sub * h * w_sub)
+            h_h = 4 * 0.25 * np.sum(h ** 2 * w_sub)
+            out[b] = -0.5 * (d_d[data_index[b]] + h_h - 2 * d_h)
+        return out
+
+    def test_lazy_build_then_matches_reference(self):
+        host = self._make_host(num_acs=4, num_splits=2)
+        self.assertIsNone(host._cpp_likelihood_backend)
+        data_index, templ, sf, st, sm, sn = self._make_batch(4, nb=6)
+
+        out = host.cpp_template_likelihood(data_index, templ, sf, st)
+
+        # Lazy build happened and produced the real WDM group.
+        self.assertIsNotNone(host._cpp_likelihood_backend)
+        self.assertEqual(
+            type(host._cpp_likelihood_backend.computation_groups[0]).__name__,
+            "WDMComputationGroup",
+        )
+        ref = self._reference(host, data_index, templ, sm, sn)
+        np.testing.assert_allclose(out, ref, rtol=1e-9, atol=1e-9)
+
+    def test_parity_vs_hand_driven_dcga(self):
+        host = self._make_host(num_acs=4, num_splits=2)
+        data_index, templ, sf, st, _, _ = self._make_batch(4, nb=6)
+
+        dcga = host.cpp_likelihood_backend  # build once, reuse for both
+        pos, di, ni = dcga.unpack_indices(data_index, None)
+        coords = dcga.unpack_coords(pos, (templ.astype(float), sf, st), keep_tuple=True)
+        di, ni, coords = dcga.place_on_device((di, ni, coords))
+        ref = dcga.compute_signal_likelihood(pos, di, ni, coords)
+
+        out = host.cpp_template_likelihood(data_index, templ, sf, st)
+        np.testing.assert_allclose(out, ref, rtol=1e-12, atol=1e-12)
+
+    def test_split_layout_invariance(self):
+        h1 = self._make_host(num_acs=4, num_splits=1, seed=123)
+        h2 = self._make_host(num_acs=4, num_splits=2, seed=123)
+        data_index, templ, sf, st, _, _ = self._make_batch(4, nb=8)
+        o1 = h1.cpp_template_likelihood(data_index, templ, sf, st)
+        o2 = h2.cpp_template_likelihood(data_index, templ, sf, st)
+        np.testing.assert_allclose(o1, o2, rtol=1e-12, atol=1e-12)
+
+    def test_run_threaded_matches_serial(self):
+        host = self._make_host(num_acs=4, num_splits=2)
+        data_index, templ, sf, st, _, _ = self._make_batch(4, nb=6)
+        serial = host.cpp_template_likelihood(data_index, templ, sf, st, run_threaded=False)
+        threaded = host.cpp_template_likelihood(data_index, templ, sf, st, run_threaded=True)
+        np.testing.assert_array_equal(serial, threaded)
+
+    def test_empty_split_no_crash(self):
+        host = self._make_host(num_acs=4, num_splits=2)
+        # All binaries resolve to AC 0 -> split 1 is empty.
+        _, templ, sf, st, sm, sn = self._make_batch(4, nb=6)
+        data_index = np.zeros(6, dtype=np.int32)
+        out = host.cpp_template_likelihood(data_index, templ, sf, st)
+        ref = self._reference(host, data_index, templ, sm, sn)
+        np.testing.assert_allclose(out, ref, rtol=1e-9, atol=1e-9)
+
+    def test_noise_index_defaults_to_data_index(self):
+        host = self._make_host(num_acs=4, num_splits=2)
+        data_index, templ, sf, st, _, _ = self._make_batch(4, nb=6)
+        a = host.cpp_template_likelihood(data_index, templ, sf, st, noise_index=None)
+        b = host.cpp_template_likelihood(
+            data_index, templ, sf, st, noise_index=data_index.copy()
+        )
+        np.testing.assert_array_equal(a, b)
+
+    def test_dtype_coercion(self):
+        """A float32 template is coerced to data_dtype (float64) and matches."""
+        host = self._make_host(num_acs=4, num_splits=2)
+        data_index, templ, sf, st, sm, sn = self._make_batch(4, nb=6)
+        out = host.cpp_template_likelihood(
+            data_index, templ.astype(np.float32), sf.astype(np.float32), st
+        )
+        ref = self._reference(host, data_index, templ, sm, sn)
+        # float32 templates lose precision, so a looser tolerance.
+        np.testing.assert_allclose(out, ref, rtol=1e-4, atol=1e-4)
+
+    def test_stale_dd_refresh(self):
+        """(d|d) is cached at build time; refresh recomputes it after mutation."""
+        host = self._make_host(num_acs=4, num_splits=2)
+        data_index, templ, sf, st, sm, sn = self._make_batch(4, nb=6)
+        host.cpp_template_likelihood(data_index, templ, sf, st)  # build backend
+
+        # Mutate the cached (d|d) source on the stub ACs, leaving the kernel's
+        # (d|h)/(h|h) inputs untouched: the forwarder result must shift by
+        # exactly -0.5 * delta(d_d) per binary only after a refresh.
+        delta = 10.0
+        for ac in host.acs:
+            ac._d_d += delta
+        before = host.cpp_template_likelihood(data_index, templ, sf, st)
+        host.refresh_cpp_dd()
+        after = host.cpp_template_likelihood(data_index, templ, sf, st)
+        np.testing.assert_allclose(after - before, -0.5 * delta, rtol=0, atol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# FD: stub group through the forwarder (complex dtype, start_times=None).
+# ---------------------------------------------------------------------------
+
+
+class TestFDForwarderStubGroup(unittest.TestCase):
+    """``cpp_template_likelihood`` forwarder over the complex FD path,
+    driving a NumPy stub group (XYZ full-cov) with a preset backend."""
+
+    NCH = 3
+    NFREQ = 64
+    DF = 1e-3
+
+    def _make_host(self, num_acs, num_splits, seed=1):
+        rng = np.random.default_rng(seed)
+        data = (
+            rng.standard_normal((num_acs, self.NCH, self.NFREQ))
+            + 1j * rng.standard_normal((num_acs, self.NCH, self.NFREQ))
+        )
+        invC = np.zeros((num_acs, self.NCH, self.NCH, self.NFREQ), dtype=np.complex128)
+        for ac in range(num_acs):
+            for f in range(self.NFREQ):
+                A = rng.standard_normal((self.NCH, self.NCH)) + 1j * rng.standard_normal(
+                    (self.NCH, self.NCH)
+                )
+                invC[ac, :, :, f] = A @ A.conj().T + 3.0 * np.eye(self.NCH)
+        d_d = np.array(
+            [_cross_inner(data[i], data[i], invC[i], self.DF).real for i in range(num_acs)]
+        )
+        settings = FDSettings(
+            N=self.NFREQ + 1, df=self.DF, min_freq=self.DF,
+            max_freq=self.NFREQ * self.DF, force_backend="cpu",
+        )
+        host = _ACSHost(
+            settings, data, invC, d_d,
+            nchannels=self.NCH, num_splits=num_splits, data_dtype=complex,
+        )
+        # Preset a stub backend (the merged real FDComputationGroup needs an
+        # unreconciled FD binding); the forwarder uses the cached instance.
+        host._cpp_likelihood_backend = _StubFDDCGA(host)
+        host._raw = (data, invC, d_d)
+        return host
+
+    def _batch(self, num_acs, nb, seed=7):
+        rng = np.random.default_rng(seed)
+        data_index = np.tile(np.arange(num_acs), int(np.ceil(nb / num_acs)))[:nb].astype(np.int32)
+        templ = (
+            rng.standard_normal((nb, self.NCH, self.NFREQ))
+            + 1j * rng.standard_normal((nb, self.NCH, self.NFREQ))
+        )
+        start_freqs = np.full(nb, self.DF, dtype=np.float64)
+        return data_index, templ, start_freqs
+
+    def _reference(self, host, data_index, templ):
+        data, invC, d_d = host._raw
+        out = np.zeros(data_index.shape[0])
+        for b in range(data_index.shape[0]):
+            d = data[data_index[b]]
+            ic = invC[data_index[b]]
+            h = templ[b]
+            d_h = _cross_inner(d, h, ic, self.DF)
+            h_h = _cross_inner(h, h, ic, self.DF)
+            out[b] = -0.5 * (d_d[data_index[b]] + h_h - 2 * d_h).real
+        return out
+
+    def test_matches_reference_no_start_times(self):
+        host = self._make_host(num_acs=4, num_splits=2)
+        data_index, templ, sf = self._batch(4, nb=6)
+        out = host.cpp_template_likelihood(data_index, templ, sf, start_times=None)
+        ref = self._reference(host, data_index, templ)
+        np.testing.assert_allclose(out, ref, rtol=1e-10, atol=1e-10)
+
+    def test_parity_vs_hand_driven_dcga(self):
+        host = self._make_host(num_acs=4, num_splits=2)
+        data_index, templ, sf = self._batch(4, nb=6)
+        dcga = host.cpp_likelihood_backend
+        pos, di, ni = dcga.unpack_indices(data_index, None)
+        coords = dcga.unpack_coords(pos, (templ.astype(complex), sf), keep_tuple=True)
+        di, ni, coords = dcga.place_on_device((di, ni, coords))
+        ref = dcga.compute_signal_likelihood(pos, di, ni, coords)
+        out = host.cpp_template_likelihood(data_index, templ, sf, start_times=None)
+        np.testing.assert_allclose(out, ref, rtol=1e-12, atol=1e-12)
+
+    def test_split_layout_invariance(self):
+        h1 = self._make_host(num_acs=4, num_splits=1, seed=99)
+        h2 = self._make_host(num_acs=4, num_splits=2, seed=99)
+        data_index, templ, sf = self._batch(4, nb=8)
+        o1 = h1.cpp_template_likelihood(data_index, templ, sf)
+        o2 = h2.cpp_template_likelihood(data_index, templ, sf)
+        np.testing.assert_allclose(o1, o2, rtol=1e-12, atol=1e-12)
+
+    def test_run_threaded_matches_serial(self):
+        host = self._make_host(num_acs=4, num_splits=2)
+        data_index, templ, sf = self._batch(4, nb=6)
+        s = host.cpp_template_likelihood(data_index, templ, sf, run_threaded=False)
+        t = host.cpp_template_likelihood(data_index, templ, sf, run_threaded=True)
+        np.testing.assert_array_equal(s, t)
+
+    def test_dtype_coercion_complex64(self):
+        host = self._make_host(num_acs=4, num_splits=2)
+        data_index, templ, sf = self._batch(4, nb=6)
+        out = host.cpp_template_likelihood(data_index, templ.astype(np.complex64), sf)
+        ref = self._reference(host, data_index, templ)
+        np.testing.assert_allclose(out, ref, rtol=1e-4, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# State semantics of the lazy accessor + kwargs setter.
+# ---------------------------------------------------------------------------
+
+
+class TestForwarderStateSemantics(unittest.TestCase):
+    NCH, NFREQ, DF = 3, 16, 1e-3
+
+    def _host(self, num_splits=2):
+        rng = np.random.default_rng(3)
+        num_acs = 4
+        data = (
+            rng.standard_normal((num_acs, self.NCH, self.NFREQ))
+            + 1j * rng.standard_normal((num_acs, self.NCH, self.NFREQ))
+        )
+        invC = np.zeros((num_acs, self.NCH, self.NCH, self.NFREQ), dtype=np.complex128)
+        for ac in range(num_acs):
+            for f in range(self.NFREQ):
+                A = rng.standard_normal((self.NCH, self.NCH)) + 1j * rng.standard_normal(
+                    (self.NCH, self.NCH)
+                )
+                invC[ac, :, :, f] = A @ A.conj().T + 3.0 * np.eye(self.NCH)
+        d_d = np.zeros(num_acs)
+        settings = FDSettings(
+            N=self.NFREQ + 1, df=self.DF, min_freq=self.DF,
+            max_freq=self.NFREQ * self.DF, force_backend="cpu",
+        )
+        return _ACSHost(
+            settings, data, invC, d_d, nchannels=self.NCH,
+            num_splits=num_splits, data_dtype=complex,
+            domain_group_kwargs={"tdi_type": "XYZ"},
+        )
+
+    def test_lazy_none_until_accessed(self):
+        host = self._host()
+        self.assertIsNone(host._cpp_likelihood_backend)
+        # Inject a stub coordinator via the accessor's cache; real FD build is
+        # unreconciled, so we test the *caching* behaviour directly.
+        host._cpp_likelihood_backend = _StubFDDCGA(host)
+        first = host.cpp_likelihood_backend
+        self.assertIs(first, host.cpp_likelihood_backend)  # cached, same object
+        self.assertIs(first, host.domain_computation_group)  # alias
+
+    def test_domain_group_kwargs_setter_invalidates_cache(self):
+        host = self._host()
+        host._cpp_likelihood_backend = _StubFDDCGA(host)
+        self.assertIsNotNone(host._cpp_likelihood_backend)
+        host.domain_group_kwargs = {"tdi_type": "AET"}
+        # Setter must reset the cached backend and store the new kwargs.
+        self.assertIsNone(host._cpp_likelihood_backend)
+        self.assertEqual(host.domain_group_kwargs, {"tdi_type": "AET"})
+
+    def test_refresh_noop_when_not_built(self):
+        host = self._host()
+        self.assertIsNone(host._cpp_likelihood_backend)
+        host.refresh_cpp_dd()  # must not raise
+        self.assertIsNone(host._cpp_likelihood_backend)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_aca_cpp_likelihood_backend.py
+++ b/tests/test_aca_cpp_likelihood_backend.py
@@ -11,7 +11,7 @@ Covers the additive integration in :class:`AnalysisContainerArray`:
 
 The forwarder is pure plumbing over the DCGA primitives
 (``unpack_indices`` / ``unpack_coords`` / ``place_on_device`` /
-``compute_signal_likelihood``), all already covered by
+``cpp_signal_likelihood``), all already covered by
 ``test_multi_gpu_placement.py``. Here we exercise the *forwarder* code path
 itself, two ways:
 
@@ -104,8 +104,8 @@ class _ACSHost:
     compute_d_d_terms = _ACA.compute_d_d_terms
     compute_noise_terms = _ACA.compute_noise_terms
     _compute_group_likelihood = _ACA._compute_group_likelihood
-    compute_signal_likelihood = _ACA.compute_signal_likelihood
-    compute_psd_likelihood = _ACA.compute_psd_likelihood
+    cpp_signal_likelihood = _ACA.cpp_signal_likelihood
+    cpp_psd_likelihood = _ACA.cpp_psd_likelihood
     _cpp_strategy_class = _ACA._cpp_strategy_class
     _build_cpp_splits = _ACA._build_cpp_splits
     _ensure_cpp_splits = _ACA._ensure_cpp_splits
@@ -285,7 +285,7 @@ class TestWDMForwarderRealKernel(unittest.TestCase):
         pos, di, ni = host.unpack_indices(data_index, None)
         coords = host.unpack_coords(pos, (templ.astype(float), sf, st), keep_tuple=True)
         di, ni, coords = host.place_on_device((di, ni, coords))
-        ref = host.compute_signal_likelihood(pos, di, ni, coords)
+        ref = host.cpp_signal_likelihood(pos, di, ni, coords)
 
         out = host.cpp_template_likelihood(data_index, templ, sf, st)
         np.testing.assert_allclose(out, ref, rtol=1e-12, atol=1e-12)
@@ -433,7 +433,7 @@ class TestFDForwarderRealKernel(unittest.TestCase):
         pos, di, ni = host.unpack_indices(data_index, None)
         coords = host.unpack_coords(pos, (templ.astype(complex), sf), keep_tuple=True)
         di, ni, coords = host.place_on_device((di, ni, coords))
-        ref = host.compute_signal_likelihood(pos, di, ni, coords)
+        ref = host.cpp_signal_likelihood(pos, di, ni, coords)
         out = host.cpp_template_likelihood(data_index, templ, sf, start_times=None)
         np.testing.assert_allclose(out, ref, rtol=1e-12, atol=1e-12)
 
@@ -545,7 +545,7 @@ class TestSTFTForwarderRealKernel(unittest.TestCase):
         pos, di, ni = host.unpack_indices(data_index, None)
         coords = host.unpack_coords(pos, (templ.astype(complex), sf, st), keep_tuple=True)
         di, ni, coords = host.place_on_device((di, ni, coords))
-        ref = host.compute_signal_likelihood(pos, di, ni, coords)
+        ref = host.cpp_signal_likelihood(pos, di, ni, coords)
         out = host.cpp_template_likelihood(data_index, templ, sf, start_times=st)
         np.testing.assert_allclose(out, ref, rtol=1e-12, atol=1e-12)
 

--- a/tests/test_aca_cpp_likelihood_backend.py
+++ b/tests/test_aca_cpp_likelihood_backend.py
@@ -41,10 +41,7 @@ import unittest
 import numpy as np
 
 from lisatools.analysiscontainer import AnalysisContainerArray as _ACA
-from lisatools.domaincomputation import (
-    BaseDomainComputationGroup,
-    DomainComputationGroupArray,
-)
+from lisatools.domaincomputation import BaseDomainComputationGroup
 from lisatools.domains import FDSettings, WDMSettings
 
 
@@ -90,12 +87,34 @@ class _ACSHost:
     implementations, assigned here so the test exercises production code.
     """
 
-    # --- borrowed, under test ---
+    # --- borrowed from AnalysisContainerArray, under test ---
     cpp_template_likelihood = _ACA.cpp_template_likelihood
     refresh_cpp_dd = _ACA.refresh_cpp_dd
-    cpp_likelihood_backend = _ACA.cpp_likelihood_backend  # property
-    domain_computation_group = _ACA.domain_computation_group  # property
-    domain_group_kwargs = _ACA.domain_group_kwargs  # property (+ setter)
+    unpack_indices = _ACA.unpack_indices
+    unpack_coords = _ACA.unpack_coords
+    place_on_device = _ACA.place_on_device
+    _loop_operation = _ACA._loop_operation
+    device_context = _ACA.device_context
+    free_gpu_memory = _ACA.free_gpu_memory
+    _to_host = _ACA._to_host
+    synchronize = _ACA.synchronize
+    compute_d_d_terms = _ACA.compute_d_d_terms
+    compute_noise_terms = _ACA.compute_noise_terms
+    _compute_group_likelihood = _ACA._compute_group_likelihood
+    compute_signal_likelihood = _ACA.compute_signal_likelihood
+    compute_psd_likelihood = _ACA.compute_psd_likelihood
+    _cpp_strategy_class = _ACA._cpp_strategy_class
+    _build_cpp_splits = _ACA._build_cpp_splits
+    _ensure_cpp_splits = _ACA._ensure_cpp_splits
+    cpp_split = _ACA.cpp_split
+    # borrowed properties
+    cpp_likelihood_backend = _ACA.cpp_likelihood_backend
+    domain_computation_group = _ACA.domain_computation_group
+    domain_group_kwargs = _ACA.domain_group_kwargs
+    num_splits = _ACA.num_splits
+    ac_to_split = _ACA.ac_to_split
+    cpp_splits = _ACA.cpp_splits
+    thread_pool = _ACA.thread_pool
 
     xp = np
     run_threaded = False
@@ -139,9 +158,16 @@ class _ACSHost:
         ]
         self.acs = np.asarray([_StubAC(v) for v in d_d_values], dtype=object)
 
+        # Routing table the borrowed unpack_indices reads (ac_to_split = split_map).
+        self.ac_to_intra = np.empty(num_acs, dtype=np.int32)
+        for split_id, entries in enumerate(self.gpu_splits):
+            self.ac_to_intra[entries] = np.arange(len(entries), dtype=np.int32)
+
         # Lazy-state attributes the borrowed accessors read/write.
         self._domain_group_kwargs = dict(domain_group_kwargs or {})
+        self._cpp_splits = None
         self._cpp_likelihood_backend = None
+        self._thread_pool = None
 
 
 # ---------------------------------------------------------------------------
@@ -180,10 +206,12 @@ class _StubFDComputationGroup(BaseDomainComputationGroup):
         return d_h, h_h
 
 
-class _StubFDDCGA(DomainComputationGroupArray):
-    @property
-    def computation_group_class(self):
-        return _StubFDComputationGroup
+def _use_stub_fd_strategy(host):
+    """Point an ACS host at the NumPy FD stub strategy (the merged real
+    FDComputationGroup needs an unreconciled FD binding). Instance-shadows the
+    borrowed ``_cpp_strategy_class`` so ``_build_cpp_splits`` builds the stub."""
+    host._cpp_strategy_class = lambda: _StubFDComputationGroup
+    return host
 
 
 # ---------------------------------------------------------------------------
@@ -261,15 +289,15 @@ class TestWDMForwarderRealKernel(unittest.TestCase):
 
     def test_lazy_build_then_matches_reference(self):
         host = self._make_host(num_acs=4, num_splits=2)
-        self.assertIsNone(host._cpp_likelihood_backend)
+        self.assertIsNone(host._cpp_splits)
         data_index, templ, sf, st, sm, sn = self._make_batch(4, nb=6)
 
         out = host.cpp_template_likelihood(data_index, templ, sf, st)
 
-        # Lazy build happened and produced the real WDM group.
-        self.assertIsNotNone(host._cpp_likelihood_backend)
+        # Lazy build happened and produced the real WDM strategy per split.
+        self.assertIsNotNone(host._cpp_splits)
         self.assertEqual(
-            type(host._cpp_likelihood_backend.computation_groups[0]).__name__,
+            type(host.cpp_splits[0]).__name__,
             "WDMComputationGroup",
         )
         ref = self._reference(host, data_index, templ, sm, sn)
@@ -387,9 +415,9 @@ class TestFDForwarderStubGroup(unittest.TestCase):
             settings, data, invC, d_d,
             nchannels=self.NCH, num_splits=num_splits, data_dtype=complex,
         )
-        # Preset a stub backend (the merged real FDComputationGroup needs an
-        # unreconciled FD binding); the forwarder uses the cached instance.
-        host._cpp_likelihood_backend = _StubFDDCGA(host)
+        # The merged real FDComputationGroup needs an unreconciled FD binding,
+        # so build the NumPy FD stub strategy instead (via the strategy hook).
+        _use_stub_fd_strategy(host)
         host._raw = (data, invC, d_d)
         return host
 
@@ -483,36 +511,39 @@ class TestForwarderStateSemantics(unittest.TestCase):
             N=self.NFREQ + 1, df=self.DF, min_freq=self.DF,
             max_freq=self.NFREQ * self.DF, force_backend="cpu",
         )
-        return _ACSHost(
-            settings, data, invC, d_d, nchannels=self.NCH,
-            num_splits=num_splits, data_dtype=complex,
-            domain_group_kwargs={"tdi_type": "XYZ"},
+        return _use_stub_fd_strategy(
+            _ACSHost(
+                settings, data, invC, d_d, nchannels=self.NCH,
+                num_splits=num_splits, data_dtype=complex,
+                domain_group_kwargs={"tdi_type": "XYZ"},
+            )
         )
 
     def test_lazy_none_until_accessed(self):
         host = self._host()
+        self.assertIsNone(host._cpp_splits)
         self.assertIsNone(host._cpp_likelihood_backend)
-        # Inject a stub coordinator via the accessor's cache; real FD build is
-        # unreconciled, so we test the *caching* behaviour directly.
-        host._cpp_likelihood_backend = _StubFDDCGA(host)
-        first = host.cpp_likelihood_backend
+        first = host.cpp_likelihood_backend  # builds strategies + the shim
+        self.assertIsNotNone(host._cpp_splits)
         self.assertIs(first, host.cpp_likelihood_backend)  # cached, same object
         self.assertIs(first, host.domain_computation_group)  # alias
 
     def test_domain_group_kwargs_setter_invalidates_cache(self):
         host = self._host()
-        host._cpp_likelihood_backend = _StubFDDCGA(host)
+        host.cpp_likelihood_backend  # build strategies + shim
         self.assertIsNotNone(host._cpp_likelihood_backend)
+        self.assertIsNotNone(host._cpp_splits)
         host.domain_group_kwargs = {"tdi_type": "AET"}
-        # Setter must reset the cached backend and store the new kwargs.
+        # Setter must reset both the strategy list and the shim cache.
         self.assertIsNone(host._cpp_likelihood_backend)
+        self.assertIsNone(host._cpp_splits)
         self.assertEqual(host.domain_group_kwargs, {"tdi_type": "AET"})
 
     def test_refresh_noop_when_not_built(self):
         host = self._host()
-        self.assertIsNone(host._cpp_likelihood_backend)
+        self.assertIsNone(host._cpp_splits)
         host.refresh_cpp_dd()  # must not raise
-        self.assertIsNone(host._cpp_likelihood_backend)
+        self.assertIsNone(host._cpp_splits)
 
 
 if __name__ == "__main__":

--- a/tests/test_aca_cpp_likelihood_backend.py
+++ b/tests/test_aca_cpp_likelihood_backend.py
@@ -19,10 +19,10 @@ itself, two ways:
   likelihood kernel** (``WDMDomainWrap``) — the lazily-built real
   ``WDMComputationGroup`` runs on CPU. This validates the forwarder feeding a
   genuine kernel end-to-end, including the lazy backend build.
-* **FD** (:class:`TestFDForwarderStubGroup`) drives a NumPy stub group (the
-  established pattern from ``test_multi_gpu_placement.py``; the merged real
-  ``FDComputationGroup`` requires the not-yet-reconciled STFT-era FD binding).
-  This covers the complex-dtype + ``start_times=None`` forwarder path.
+* **FD** (:class:`TestFDForwarderRealKernel`) drives the **real C++ FD
+  likelihood kernel** (``FDDomainForStftWrap``) — the lazily-built real
+  ``FDComputationGroup`` runs on CPU and matches the full-covariance reference
+  to machine precision. Covers the complex-dtype + ``start_times=None`` path.
 
 STFT shares the identical forwarder code path (the forwarder treats the
 template opaquely — it only coerces dtype and scatters); WDM (4-index
@@ -42,7 +42,6 @@ import warnings
 import numpy as np
 
 from lisatools.analysiscontainer import AnalysisContainerArray as _ACA
-from lisatools.domaincomputation import BaseDomainComputationGroup
 from lisatools.domains import FDSettings, WDMSettings
 
 
@@ -172,7 +171,7 @@ class _ACSHost:
 
 
 # ---------------------------------------------------------------------------
-# FD stub group + coordinator (NumPy XYZ reference), from test_multi_gpu_placement.
+# Full-covariance XYZ FD inner-product reference (from test_multi_gpu_placement).
 # ---------------------------------------------------------------------------
 
 
@@ -184,35 +183,6 @@ def _cross_inner(a, b, invC, df):
         for j in range(nch):
             acc += np.sum(np.conj(a[i]) * invC[i, j] * b[j])
     return 4.0 * df * acc
-
-
-class _StubFDComputationGroup(BaseDomainComputationGroup):
-    """NumPy stand-in for ``FDComputationGroup`` (XYZ full-cov reference)."""
-
-    def compute_signal_likelihood_terms(
-        self, data_index, noise_index, template_vals, start_freqs, start_times=None, **_
-    ):
-        nb, nch, nfreq = template_vals.shape
-        data = self.data_arr.reshape(self.num_data, nch, nfreq)
-        invC = self.invC_arr.reshape(self.num_noise, nch, nch, nfreq)
-        df = self.settings.df
-        d_h = np.zeros(nb, dtype=np.complex128)
-        h_h = np.zeros(nb, dtype=np.complex128)
-        for b in range(nb):
-            d = data[int(data_index[b])]
-            ic = invC[int(noise_index[b])]
-            h = template_vals[b]
-            d_h[b] = _cross_inner(d, h, ic, df)
-            h_h[b] = _cross_inner(h, h, ic, df)
-        return d_h, h_h
-
-
-def _use_stub_fd_strategy(host):
-    """Point an ACS host at the NumPy FD stub strategy (the merged real
-    FDComputationGroup needs an unreconciled FD binding). Instance-shadows the
-    borrowed ``_cpp_strategy_class`` so ``_build_cpp_splits`` builds the stub."""
-    host._cpp_strategy_class = lambda: _StubFDComputationGroup
-    return host
 
 
 # ---------------------------------------------------------------------------
@@ -384,9 +354,9 @@ class TestWDMForwarderRealKernel(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
-class TestFDForwarderStubGroup(unittest.TestCase):
+class TestFDForwarderRealKernel(unittest.TestCase):
     """``cpp_template_likelihood`` forwarder over the complex FD path,
-    driving a NumPy stub group (XYZ full-cov) with a preset backend."""
+    driving the real C++ ``FDComputationGroup`` (``FDDomainForStftWrap``)."""
 
     NCH = 3
     NFREQ = 64
@@ -416,9 +386,11 @@ class TestFDForwarderStubGroup(unittest.TestCase):
             settings, data, invC, d_d,
             nchannels=self.NCH, num_splits=num_splits, data_dtype=complex,
         )
-        # The merged real FDComputationGroup needs an unreconciled FD binding,
-        # so build the NumPy FD stub strategy instead (via the strategy hook).
-        _use_stub_fd_strategy(host)
+        # Drives the real FDComputationGroup: the borrowed _cpp_strategy_class
+        # dispatches FDSettings -> FDComputationGroup, and the stub
+        # orbits/sensitivity satisfy build_cpp_objects (the signal inner
+        # products don't use orbits). The real FDDomainForStftWrap kernel
+        # matches _cross_inner to machine precision.
         host._raw = (data, invC, d_d)
         return host
 
@@ -512,12 +484,10 @@ class TestForwarderStateSemantics(unittest.TestCase):
             N=self.NFREQ + 1, df=self.DF, min_freq=self.DF,
             max_freq=self.NFREQ * self.DF, force_backend="cpu",
         )
-        return _use_stub_fd_strategy(
-            _ACSHost(
-                settings, data, invC, d_d, nchannels=self.NCH,
-                num_splits=num_splits, data_dtype=complex,
-                domain_group_kwargs={"tdi_type": "XYZ"},
-            )
+        return _ACSHost(
+            settings, data, invC, d_d, nchannels=self.NCH,
+            num_splits=num_splits, data_dtype=complex,
+            domain_group_kwargs={"tdi_type": "XYZ"},
         )
 
     def test_lazy_none_until_accessed(self):

--- a/tests/test_aca_cpp_likelihood_backend.py
+++ b/tests/test_aca_cpp_likelihood_backend.py
@@ -9,7 +9,7 @@ Covers the additive integration in :class:`AnalysisContainerArray`:
   that drives the multi-split propagation through the owned backend; and
 * :meth:`refresh_cpp_dd` for the cached ``(d|d)`` term.
 
-The forwarder is pure plumbing over the DCGA primitives
+The forwarder is pure plumbing over the ACA primitives
 (``unpack_indices`` / ``unpack_coords`` / ``place_on_device`` /
 ``cpp_signal_likelihood``), all already covered by
 ``test_multi_gpu_placement.py``. Here we exercise the *forwarder* code path
@@ -353,7 +353,7 @@ class TestWDMForwarderRealKernel(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# FD: stub group through the forwarder (complex dtype, start_times=None).
+# FD: real C++ kernel through the forwarder (complex dtype, start_times=None).
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_aca_cpp_likelihood_backend.py
+++ b/tests/test_aca_cpp_likelihood_backend.py
@@ -24,10 +24,13 @@ itself, two ways:
   ``FDComputationGroup`` runs on CPU and matches the full-covariance reference
   to machine precision. Covers the complex-dtype + ``start_times=None`` path.
 
-STFT shares the identical forwarder code path (the forwarder treats the
-template opaquely — it only coerces dtype and scatters); WDM (4-index
-sub-grids, real) and FD (3-index, complex) together exercise the shape and
-dtype generality.
+* **STFT** (:class:`TestSTFTForwarderRealKernel`) drives the **real C++ STFT
+  kernel** (``STFTDomainWrap``) over a 4-D time-frequency template. The STFT
+  inner product is the FD full-cov product summed over time bins (``4 df`` per
+  ``(t,f)`` pixel), so the same ``_cross_inner`` reference applies.
+
+Together WDM (4-index, real), FD (3-index, complex) and STFT (4-index, complex)
+exercise the shape and dtype generality of the forwarder.
 
 We drive the *real* ``AnalysisContainerArray`` methods (borrowed onto a
 lightweight ACS host that carries exactly the attributes the backend reads),
@@ -42,7 +45,7 @@ import warnings
 import numpy as np
 
 from lisatools.analysiscontainer import AnalysisContainerArray as _ACA
-from lisatools.domains import FDSettings, WDMSettings
+from lisatools.domains import FDSettings, STFTSettings, WDMSettings
 
 
 # ---------------------------------------------------------------------------
@@ -453,6 +456,120 @@ class TestFDForwarderRealKernel(unittest.TestCase):
         host = self._make_host(num_acs=4, num_splits=2)
         data_index, templ, sf = self._batch(4, nb=6)
         out = host.cpp_template_likelihood(data_index, templ.astype(np.complex64), sf)
+        ref = self._reference(host, data_index, templ)
+        np.testing.assert_allclose(out, ref, rtol=1e-4, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# STFT: real C++ time-frequency kernel through the forwarder.
+# ---------------------------------------------------------------------------
+
+
+class TestSTFTForwarderRealKernel(unittest.TestCase):
+    """``cpp_template_likelihood`` forwarder over the time-frequency STFT path,
+    driving the real C++ ``STFTComputationGroup`` (``STFTDomainWrap``). The STFT
+    inner product is the FD full-cov product summed over time bins (``4 df`` per
+    ``(t, f)`` pixel), so the same ``_cross_inner`` reference applies with
+    ``(nch, NT, NF)`` arrays. ``start_times``/``start_freqs`` are chosen to put
+    the template sub-grid at index ``(0, 0)`` (full-grid templates)."""
+
+    NCH = 3
+    NT = 4
+    NFREQ = 8  # == NF_active given min_freq=DF, max_freq=NFREQ*DF, NF=NFREQ+1
+    DT = 10.0
+    DF = 1e-3
+
+    def _make_host(self, num_acs, num_splits, seed=1):
+        rng = np.random.default_rng(seed)
+        shp = (num_acs, self.NCH, self.NT, self.NFREQ)
+        data = rng.standard_normal(shp) + 1j * rng.standard_normal(shp)
+        invC = np.zeros(
+            (num_acs, self.NCH, self.NCH, self.NT, self.NFREQ), dtype=np.complex128
+        )
+        for ac in range(num_acs):
+            for t in range(self.NT):
+                for f in range(self.NFREQ):
+                    A = rng.standard_normal((self.NCH, self.NCH)) + 1j * rng.standard_normal(
+                        (self.NCH, self.NCH)
+                    )
+                    invC[ac, :, :, t, f] = A @ A.conj().T + 3.0 * np.eye(self.NCH)
+        d_d = np.array(
+            [_cross_inner(data[i], data[i], invC[i], self.DF).real for i in range(num_acs)]
+        )
+        settings = STFTSettings(
+            t0=0.0, dt=self.DT, df=self.DF, NT=self.NT, NF=self.NFREQ + 1,
+            min_freq=self.DF, max_freq=self.NFREQ * self.DF, force_backend="cpu",
+        )
+        assert settings.NF_active == self.NFREQ
+        host = _ACSHost(
+            settings, data, invC, d_d,
+            nchannels=self.NCH, num_splits=num_splits, data_dtype=complex,
+        )
+        # Real STFTComputationGroup (STFTDomainWrap); stub orbits/sensitivity
+        # satisfy build_cpp_objects (signal inner products don't use orbits).
+        host._raw = (data, invC, d_d)
+        return host
+
+    def _batch(self, num_acs, nb, seed=7):
+        rng = np.random.default_rng(seed)
+        data_index = np.tile(np.arange(num_acs), int(np.ceil(nb / num_acs)))[:nb].astype(np.int32)
+        shp = (nb, self.NCH, self.NT, self.NFREQ)
+        templ = rng.standard_normal(shp) + 1j * rng.standard_normal(shp)
+        start_freqs = np.full(nb, self.DF, dtype=np.float64)  # -> freq index 0
+        start_times = np.full(nb, 0.0, dtype=np.float64)      # -> time index 0
+        return data_index, templ, start_freqs, start_times
+
+    def _reference(self, host, data_index, templ):
+        data, invC, d_d = host._raw
+        out = np.zeros(data_index.shape[0])
+        for b in range(data_index.shape[0]):
+            d = data[data_index[b]]
+            ic = invC[data_index[b]]
+            h = templ[b]
+            d_h = _cross_inner(d, h, ic, self.DF)
+            h_h = _cross_inner(h, h, ic, self.DF)
+            out[b] = -0.5 * (d_d[data_index[b]] + h_h - 2 * d_h).real
+        return out
+
+    def test_matches_reference(self):
+        host = self._make_host(num_acs=4, num_splits=2)
+        data_index, templ, sf, st = self._batch(4, nb=6)
+        out = host.cpp_template_likelihood(data_index, templ, sf, start_times=st)
+        ref = self._reference(host, data_index, templ)
+        np.testing.assert_allclose(out, ref, rtol=1e-10, atol=1e-10)
+
+    def test_parity_vs_hand_driven_coordinator(self):
+        host = self._make_host(num_acs=4, num_splits=2)
+        data_index, templ, sf, st = self._batch(4, nb=6)
+        host._ensure_cpp_splits()
+        pos, di, ni = host.unpack_indices(data_index, None)
+        coords = host.unpack_coords(pos, (templ.astype(complex), sf, st), keep_tuple=True)
+        di, ni, coords = host.place_on_device((di, ni, coords))
+        ref = host.compute_signal_likelihood(pos, di, ni, coords)
+        out = host.cpp_template_likelihood(data_index, templ, sf, start_times=st)
+        np.testing.assert_allclose(out, ref, rtol=1e-12, atol=1e-12)
+
+    def test_split_layout_invariance(self):
+        h1 = self._make_host(num_acs=4, num_splits=1, seed=99)
+        h2 = self._make_host(num_acs=4, num_splits=2, seed=99)
+        data_index, templ, sf, st = self._batch(4, nb=8)
+        o1 = h1.cpp_template_likelihood(data_index, templ, sf, start_times=st)
+        o2 = h2.cpp_template_likelihood(data_index, templ, sf, start_times=st)
+        np.testing.assert_allclose(o1, o2, rtol=1e-12, atol=1e-12)
+
+    def test_run_threaded_matches_serial(self):
+        host = self._make_host(num_acs=4, num_splits=2)
+        data_index, templ, sf, st = self._batch(4, nb=6)
+        s = host.cpp_template_likelihood(data_index, templ, sf, start_times=st, run_threaded=False)
+        t = host.cpp_template_likelihood(data_index, templ, sf, start_times=st, run_threaded=True)
+        np.testing.assert_array_equal(s, t)
+
+    def test_dtype_coercion_complex64(self):
+        host = self._make_host(num_acs=4, num_splits=2)
+        data_index, templ, sf, st = self._batch(4, nb=6)
+        out = host.cpp_template_likelihood(
+            data_index, templ.astype(np.complex64), sf, start_times=st
+        )
         ref = self._reference(host, data_index, templ)
         np.testing.assert_allclose(out, ref, rtol=1e-4, atol=1e-4)
 

--- a/tests/test_aca_cpp_likelihood_backend.py
+++ b/tests/test_aca_cpp_likelihood_backend.py
@@ -37,6 +37,7 @@ so the code under test is the production forwarder, not a re-implementation.
 from __future__ import annotations
 
 import unittest
+import warnings
 
 import numpy as np
 
@@ -303,15 +304,15 @@ class TestWDMForwarderRealKernel(unittest.TestCase):
         ref = self._reference(host, data_index, templ, sm, sn)
         np.testing.assert_allclose(out, ref, rtol=1e-9, atol=1e-9)
 
-    def test_parity_vs_hand_driven_dcga(self):
+    def test_parity_vs_hand_driven_coordinator(self):
         host = self._make_host(num_acs=4, num_splits=2)
         data_index, templ, sf, st, _, _ = self._make_batch(4, nb=6)
 
-        dcga = host.cpp_likelihood_backend  # build once, reuse for both
-        pos, di, ni = dcga.unpack_indices(data_index, None)
-        coords = dcga.unpack_coords(pos, (templ.astype(float), sf, st), keep_tuple=True)
-        di, ni, coords = dcga.place_on_device((di, ni, coords))
-        ref = dcga.compute_signal_likelihood(pos, di, ni, coords)
+        host._ensure_cpp_splits()  # build the per-split strategies once
+        pos, di, ni = host.unpack_indices(data_index, None)
+        coords = host.unpack_coords(pos, (templ.astype(float), sf, st), keep_tuple=True)
+        di, ni, coords = host.place_on_device((di, ni, coords))
+        ref = host.compute_signal_likelihood(pos, di, ni, coords)
 
         out = host.cpp_template_likelihood(data_index, templ, sf, st)
         np.testing.assert_allclose(out, ref, rtol=1e-12, atol=1e-12)
@@ -450,14 +451,14 @@ class TestFDForwarderStubGroup(unittest.TestCase):
         ref = self._reference(host, data_index, templ)
         np.testing.assert_allclose(out, ref, rtol=1e-10, atol=1e-10)
 
-    def test_parity_vs_hand_driven_dcga(self):
+    def test_parity_vs_hand_driven_coordinator(self):
         host = self._make_host(num_acs=4, num_splits=2)
         data_index, templ, sf = self._batch(4, nb=6)
-        dcga = host.cpp_likelihood_backend
-        pos, di, ni = dcga.unpack_indices(data_index, None)
-        coords = dcga.unpack_coords(pos, (templ.astype(complex), sf), keep_tuple=True)
-        di, ni, coords = dcga.place_on_device((di, ni, coords))
-        ref = dcga.compute_signal_likelihood(pos, di, ni, coords)
+        host._ensure_cpp_splits()
+        pos, di, ni = host.unpack_indices(data_index, None)
+        coords = host.unpack_coords(pos, (templ.astype(complex), sf), keep_tuple=True)
+        di, ni, coords = host.place_on_device((di, ni, coords))
+        ref = host.compute_signal_likelihood(pos, di, ni, coords)
         out = host.cpp_template_likelihood(data_index, templ, sf, start_times=None)
         np.testing.assert_allclose(out, ref, rtol=1e-12, atol=1e-12)
 
@@ -544,6 +545,26 @@ class TestForwarderStateSemantics(unittest.TestCase):
         self.assertIsNone(host._cpp_splits)
         host.refresh_cpp_dd()  # must not raise
         self.assertIsNone(host._cpp_splits)
+
+    def test_direct_construction_emits_deprecation_warning(self):
+        """Constructing the deprecated alias directly warns; the ACA's own
+        ``cpp_likelihood_backend`` compat handle (``_internal=True``) does not.
+        The thin alias still forwards state to the ACA."""
+        from lisatools.domaincomputation import DomainComputationGroupArray
+
+        host = self._host()
+        with self.assertWarns(DeprecationWarning):
+            shim = DomainComputationGroupArray(host)
+        self.assertIs(shim.acs, host)
+        self.assertIs(shim.computation_groups, host.cpp_splits)
+        self.assertEqual(shim.num_splits, host.num_splits)
+        self.assertIs(shim.xp, host.xp)
+
+        # The internal compat handle must stay quiet.
+        host._cpp_likelihood_backend = None
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            host.cpp_likelihood_backend  # must not raise (no warning)
 
 
 if __name__ == "__main__":

--- a/tests/test_multi_gpu_placement.py
+++ b/tests/test_multi_gpu_placement.py
@@ -41,10 +41,8 @@ import unittest
 
 import numpy as np
 
-from lisatools.domaincomputation import (
-    BaseDomainComputationGroup,
-    DomainComputationGroupArray,
-)
+from lisatools.analysiscontainer import AnalysisContainerArray as _ACA
+from lisatools.domaincomputation import BaseDomainComputationGroup
 from lisatools.domains import FDSettings
 
 
@@ -111,17 +109,53 @@ class _StubAC:
 
 
 class _StubACS:
-    """Minimal ``AnalysisContainerArray`` shim for routing tests.
+    """Minimal ``AnalysisContainerArray`` host for the routing tests.
 
-    The coordinator and group read ``settings``, ``gpus``, ``xp``,
-    ``acs_total_entries``, ``gpu_splits``, ``split_map``,
-    ``linear_data_arr``, ``linear_psd_arr``, ``nchannels``, and the
-    object array ``acs``. We provide all of those and nothing else.
+    Builds synthetic split data and **borrows the real, now-ACA-resident
+    coordinator methods** (``unpack_indices`` / ``unpack_coords`` /
+    ``place_on_device`` / ``_loop_operation`` / ``compute_*`` / ...), so the
+    routing/dispatch code under test is the genuine library implementation.
+    Only the per-split *strategy* is stubbed: ``_cpp_strategy_class`` returns
+    the NumPy ``_StubFDComputationGroup`` (the merged real FDComputationGroup
+    needs an unreconciled FD binding).
 
-    The shim is intentionally CPU-only (``gpus=None``) so that every
-    split's ``device`` is ``None`` and the ``force_backend='cpu'``
-    assertion in ``extract_from_acs`` holds regardless of split count.
+    CPU-only (``gpus=None``) so every split's ``device`` is ``None`` and the
+    ``force_backend='cpu'`` assertion in ``extract_from_acs`` holds.
     """
+
+    # --- borrowed from AnalysisContainerArray (the absorbed DCGA coordinator) ---
+    unpack_indices = _ACA.unpack_indices
+    unpack_coords = _ACA.unpack_coords
+    place_on_device = _ACA.place_on_device
+    _loop_operation = _ACA._loop_operation
+    device_context = _ACA.device_context
+    free_gpu_memory = _ACA.free_gpu_memory
+    _to_host = _ACA._to_host
+    synchronize = _ACA.synchronize
+    compute_d_d_terms = _ACA.compute_d_d_terms
+    compute_noise_terms = _ACA.compute_noise_terms
+    _compute_group_likelihood = _ACA._compute_group_likelihood
+    compute_signal_likelihood = _ACA.compute_signal_likelihood
+    compute_psd_likelihood = _ACA.compute_psd_likelihood
+    _build_cpp_splits = _ACA._build_cpp_splits
+    _ensure_cpp_splits = _ACA._ensure_cpp_splits
+    cpp_split = _ACA.cpp_split
+    # borrowed properties
+    num_splits = _ACA.num_splits
+    ac_to_split = _ACA.ac_to_split
+    cpp_splits = _ACA.cpp_splits
+    thread_pool = _ACA.thread_pool
+    domain_group_kwargs = _ACA.domain_group_kwargs
+
+    run_threaded = False
+
+    @property
+    def computation_groups(self):
+        """Back-compat alias used by these routing tests (== ``cpp_splits``)."""
+        return self.cpp_splits
+
+    def _cpp_strategy_class(self):
+        return _StubFDComputationGroup
 
     def __init__(
         self,
@@ -207,6 +241,20 @@ class _StubACS:
         self.d_d_reference = d_d_vals
         self.acs = np.asarray([_StubAC(v) for v in d_d_vals], dtype=object)
 
+        # Routing table for the borrowed coordinator (ac_to_split = split_map).
+        self.ac_to_intra = np.empty(num_acs, dtype=np.int32)
+        for split_id, ids in enumerate(self.gpu_splits):
+            self.ac_to_intra[ids] = np.arange(len(ids), dtype=np.int32)
+
+        # Lazy-state attributes the borrowed coordinator reads/writes, then
+        # build the per-split strategies eagerly (mirrors DCGA's auto-build at
+        # construction, incl. the (d|d) snapshot the tests assert on).
+        self._domain_group_kwargs = {}
+        self._cpp_splits = None
+        self._cpp_likelihood_backend = None
+        self._thread_pool = None
+        self._build_cpp_splits()
+
 
 class _StubFDComputationGroup(BaseDomainComputationGroup):
     """NumPy stand-in for ``FDComputationGroup``.
@@ -245,19 +293,6 @@ class _StubFDComputationGroup(BaseDomainComputationGroup):
         return d_h, h_h
 
 
-class _StubDCGA(DomainComputationGroupArray):
-    """Coordinator wired to the NumPy stub group.
-
-    Only ``computation_group_class`` is overridden; every routing /
-    placement / scatter code path under test is the real library
-    implementation.
-    """
-
-    @property
-    def computation_group_class(self):
-        return _StubFDComputationGroup
-
-
 def _python_log_likelihood(data, invC, template, d_d, df):
     """Per-binary log-likelihood reference (XYZ full-cov, FD)."""
     d_h = _cross_inner(data, template, invC, df)
@@ -288,7 +323,7 @@ class TestRoutingTables(unittest.TestCase):
 
     def test_single_split(self):
         acs = _StubACS(num_acs=3, num_splits=1, num_channels=3, num_freqs=32, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         np.testing.assert_array_equal(coord.ac_to_split, np.zeros(3, dtype=int))
         np.testing.assert_array_equal(coord.ac_to_intra, np.arange(3))
@@ -298,7 +333,7 @@ class TestRoutingTables(unittest.TestCase):
         # 4 ACs split evenly across 2 splits -> split_map = [0,0,1,1],
         # intra indices reset inside each split.
         acs = _StubACS(num_acs=4, num_splits=2, num_channels=3, num_freqs=32, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         np.testing.assert_array_equal(coord.ac_to_split, np.array([0, 0, 1, 1]))
         np.testing.assert_array_equal(coord.ac_to_intra, np.array([0, 1, 0, 1]))
@@ -325,7 +360,7 @@ class TestUnpackIndices(unittest.TestCase):
 
     def test_flat_routing(self):
         acs = _StubACS(num_acs=4, num_splits=2, num_channels=3, num_freqs=16, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         nwalkers, ntemps = 4, 3
         data_index = self._tempered_index(nwalkers, ntemps)
@@ -357,7 +392,7 @@ class TestUnpackIndices(unittest.TestCase):
     def test_empty_split(self):
         """A split with no matching binaries yields zero-length entries."""
         acs = _StubACS(num_acs=4, num_splits=2, num_channels=3, num_freqs=16, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         # All binaries resolve to AC 0 -> split 0; split 1 must be empty.
         data_index = np.zeros(5, dtype=int)
@@ -382,7 +417,7 @@ class TestComputeDdTerms(unittest.TestCase):
         # The merged coordinator computes (d|d) automatically inside
         # ``initialize_computation_groups`` — no explicit call needed.
         acs = _StubACS(num_acs=4, num_splits=2, num_channels=3, num_freqs=16, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         # Each group holds exactly the d_d values of its own ACs, in
         # intra-split order.
@@ -402,7 +437,7 @@ class TestComputeDdTerms(unittest.TestCase):
         # in split order recovers the global AC order because
         # ``gpu_splits`` are contiguous blocks.
         acs = _StubACS(num_acs=4, num_splits=2, num_channels=3, num_freqs=16, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         d_d_all = coord.compute_d_d_terms(out=True)
         assert isinstance(d_d_all, list)
@@ -451,7 +486,7 @@ class TestComputeSignalLikelihoodPlacement(unittest.TestCase):
 
     def test_single_split_matches_reference(self):
         acs = _StubACS(num_acs=4, num_splits=1, num_channels=3, num_freqs=64, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         data_index, noise_index, template, start_freqs = self._build_batch(
             acs, nwalkers=4, ntemps=3
@@ -471,7 +506,7 @@ class TestComputeSignalLikelihoodPlacement(unittest.TestCase):
         # flat batch puts some binaries on each split; the return must
         # still be in the original flat order.
         acs = _StubACS(num_acs=4, num_splits=2, num_channels=3, num_freqs=64, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         data_index, noise_index, template, start_freqs = self._build_batch(
             acs, nwalkers=4, ntemps=3
@@ -489,7 +524,7 @@ class TestComputeSignalLikelihoodPlacement(unittest.TestCase):
     def test_empty_split_no_crash(self):
         """All binaries on split 0; split 1 must be skipped, not crash."""
         acs = _StubACS(num_acs=4, num_splits=2, num_channels=3, num_freqs=64, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         rng = np.random.default_rng(11)
         # AC 0 -> split 0. Every binary lives on split 0.
@@ -531,8 +566,8 @@ class TestComputeSignalLikelihoodPlacement(unittest.TestCase):
         acs1 = _StubACS(num_splits=1, **kwargs)
         acs2 = _StubACS(num_splits=2, **kwargs)
 
-        coord1 = _StubDCGA(acs1)
-        coord2 = _StubDCGA(acs2)
+        coord1 = acs1
+        coord2 = acs2
 
         data_index, noise_index, template, start_freqs = self._build_batch(
             acs1, nwalkers=4, ntemps=3
@@ -552,7 +587,7 @@ class TestComputeSignalLikelihoodPlacement(unittest.TestCase):
         guard: the merged library implements threaded dispatch.)
         """
         acs = _StubACS(num_acs=4, num_splits=2, num_channels=3, num_freqs=32, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         data_index, noise_index, template, start_freqs = self._build_batch(
             acs, nwalkers=4, ntemps=2
@@ -582,7 +617,7 @@ class TestLoopOperationCallable(unittest.TestCase):
 
     def test_callable_invoked_per_group_with_args(self):
         acs = _StubACS(num_acs=4, num_splits=2, num_channels=3, num_freqs=16, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         calls = []
 
@@ -601,7 +636,7 @@ class TestLoopOperationCallable(unittest.TestCase):
 
     def test_callable_defaults_empty_args_kwargs(self):
         acs = _StubACS(num_acs=6, num_splits=3, num_channels=3, num_freqs=16, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         counter = {"n": 0}
 
@@ -614,7 +649,7 @@ class TestLoopOperationCallable(unittest.TestCase):
 
     def test_args_length_mismatch_raises(self):
         acs = _StubACS(num_acs=4, num_splits=2, num_channels=3, num_freqs=16, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         with self.assertRaisesRegex(ValueError, "must match the number of splits"):
             coord._loop_operation(lambda x: x, operation_args_per_split=[(1,)])
@@ -622,7 +657,7 @@ class TestLoopOperationCallable(unittest.TestCase):
     def test_positions_short_circuit_skips_empty_split(self):
         """Empty splits yield ``None`` and never invoke the operation."""
         acs = _StubACS(num_acs=4, num_splits=2, num_channels=3, num_freqs=16, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         calls = []
 
@@ -661,7 +696,7 @@ class TestUnpackCoords(unittest.TestCase):
 
     def test_single_array_sliced_per_split(self):
         acs = _StubACS(num_acs=4, num_splits=2, num_channels=3, num_freqs=16, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         data_index = np.array([0, 3, 1, 2, 0, 2], dtype=np.int32)
         coords = np.column_stack(
@@ -681,7 +716,7 @@ class TestUnpackCoords(unittest.TestCase):
     def test_tuple_coords_per_split(self):
         """Multi-branch coordinate tuples stay tuples per split."""
         acs = _StubACS(num_acs=4, num_splits=2, num_channels=3, num_freqs=16, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         data_index = np.array([0, 3, 2, 1, 0], dtype=np.int32)
         c0 = np.arange(data_index.shape[0], dtype=np.float64)
@@ -699,7 +734,7 @@ class TestUnpackCoords(unittest.TestCase):
 
     def test_empty_split_yields_empty_tuple(self):
         acs = _StubACS(num_acs=4, num_splits=2, num_channels=3, num_freqs=16, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         data_index = np.zeros(3, dtype=np.int32)  # all on split 0
         coords = np.ones((3, 2), dtype=np.float64)
@@ -712,7 +747,7 @@ class TestUnpackCoords(unittest.TestCase):
 
     def test_keep_tuple_wraps_single_array(self):
         acs = _StubACS(num_acs=4, num_splits=2, num_channels=3, num_freqs=16, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         data_index = np.array([0, 2], dtype=np.int32)
         coords = np.arange(2, dtype=np.float64)
@@ -735,7 +770,7 @@ class TestUnpackCoords(unittest.TestCase):
 class TestPlaceOnDevice(unittest.TestCase):
     def test_cpu_round_trip_arrays_and_tuples(self):
         acs = _StubACS(num_acs=4, num_splits=2, num_channels=3, num_freqs=16, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         arrays_per_split = [np.arange(3, dtype=np.float64), np.arange(2.0)]
         tuples_per_split = [(np.ones(2), np.zeros(2)), ()]
@@ -766,7 +801,7 @@ class TestComposedLikelihoodFromCoords(unittest.TestCase):
 
     def test_matches_per_binary_reference(self):
         acs = _StubACS(num_acs=4, num_splits=2, num_channels=3, num_freqs=64, df=1e-3)
-        coord = _StubDCGA(acs)
+        coord = acs
 
         rng = np.random.default_rng(42)
         data_index = np.array([0, 1, 2, 3, 0, 2], dtype=np.int32)

--- a/tests/test_multi_gpu_placement.py
+++ b/tests/test_multi_gpu_placement.py
@@ -1,11 +1,15 @@
-"""Placement + routing tests for :class:`DomainComputationGroupArray`.
+"""Placement + routing tests for the :class:`AnalysisContainerArray` C++
+likelihood coordinator (absorbed from the former
+:class:`DomainComputationGroupArray`).
 
 These tests exercise the multi-split routing logic introduced by the
-multi-GPU refactor *without* requiring any real GPUs. We drive the
-coordinator with a lightweight ``AnalysisContainerArray`` shim that
-exposes exactly the attributes the coordinator and each
-``BaseDomainComputationGroup.extract_from_acs`` /
-``build_cpp_objects`` path read.
+multi-GPU refactor *without* requiring any real GPUs. We drive the real
+ACA coordinator methods (borrowed onto a lightweight ``_StubACS`` host)
+that read exactly the attributes the coordinator and each
+``DomainKernelStrategy.extract_from_acs`` / ``build_cpp_objects`` path
+need. (The strategy base is imported here under its back-compat alias
+``BaseDomainComputationGroup`` so the tests also cover that the alias
+still resolves.)
 
 Key properties verified:
     * ``ac_to_split`` / ``ac_to_intra`` routing tables match

--- a/tests/test_multi_gpu_placement.py
+++ b/tests/test_multi_gpu_placement.py
@@ -15,7 +15,7 @@ Key properties verified:
     * ``compute_d_d_terms`` populates each group's per-split ``d_d``
       vector in intra-split order (and runs automatically at
       coordinator construction).
-    * ``compute_signal_likelihood`` reproduces the per-binary reference
+    * ``cpp_signal_likelihood`` reproduces the per-binary reference
       and is invariant to the split layout (single split vs. two
       splits), including empty splits.
     * ``run_threaded=True`` (ThreadPoolExecutor dispatch) matches the
@@ -135,8 +135,8 @@ class _StubACS:
     compute_d_d_terms = _ACA.compute_d_d_terms
     compute_noise_terms = _ACA.compute_noise_terms
     _compute_group_likelihood = _ACA._compute_group_likelihood
-    compute_signal_likelihood = _ACA.compute_signal_likelihood
-    compute_psd_likelihood = _ACA.compute_psd_likelihood
+    cpp_signal_likelihood = _ACA.cpp_signal_likelihood
+    cpp_psd_likelihood = _ACA.cpp_psd_likelihood
     _build_cpp_splits = _ACA._build_cpp_splits
     _ensure_cpp_splits = _ACA._ensure_cpp_splits
     cpp_split = _ACA.cpp_split
@@ -261,7 +261,7 @@ class _StubFDComputationGroup(BaseDomainComputationGroup):
 
     The base-class machinery (``extract_from_acs``,
     ``build_cpp_objects``, ``compute_d_d_term``,
-    ``compute_signal_likelihood``) runs unmodified — only the
+    ``cpp_signal_likelihood``) runs unmodified — only the
     C++-kernel-backed ``compute_signal_likelihood_terms`` is replaced
     with the Python XYZ reference so the tests run on a CPU-only
     install (the merged ``FDComputationGroup`` requires the not-yet-
@@ -304,7 +304,7 @@ def _route_batch(coord, data_index, noise_index, *flat_arrays):
     """Build the per-split routing + ``likelihood_args`` from flat arrays.
 
     Callers who have flat ``(template, start_freqs[, start_times])``
-    tensors use this to reach the merged ``compute_signal_likelihood``
+    tensors use this to reach the merged ``cpp_signal_likelihood``
     signature, which takes the ``unpack_indices`` output plus a
     ``list[tuple]`` of per-split likelihood args.
     """
@@ -450,7 +450,7 @@ class TestComputeDdTerms(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# compute_signal_likelihood
+# cpp_signal_likelihood
 # ---------------------------------------------------------------------------
 
 
@@ -494,7 +494,7 @@ class TestComputeSignalLikelihoodPlacement(unittest.TestCase):
         positions, data_intra, noise_intra, likelihood_args = _route_batch(
             coord, data_index, noise_index, template, start_freqs
         )
-        likes = coord.compute_signal_likelihood(
+        likes = coord.cpp_signal_likelihood(
             positions, data_intra, noise_intra, likelihood_args
         )
         expected = self._reference_likes(acs, data_index, noise_index, template)
@@ -514,7 +514,7 @@ class TestComputeSignalLikelihoodPlacement(unittest.TestCase):
         positions, data_intra, noise_intra, likelihood_args = _route_batch(
             coord, data_index, noise_index, template, start_freqs
         )
-        likes = coord.compute_signal_likelihood(
+        likes = coord.cpp_signal_likelihood(
             positions, data_intra, noise_intra, likelihood_args
         )
         expected = self._reference_likes(acs, data_index, noise_index, template)
@@ -543,7 +543,7 @@ class TestComputeSignalLikelihoodPlacement(unittest.TestCase):
         # thanks to the ``positions_per_split`` short-circuit.
         assert all(len(a) == 0 for a in likelihood_args[1])
 
-        likes = coord.compute_signal_likelihood(
+        likes = coord.cpp_signal_likelihood(
             positions, data_intra, noise_intra, likelihood_args
         )
         expected = np.array(
@@ -575,8 +575,8 @@ class TestComputeSignalLikelihoodPlacement(unittest.TestCase):
 
         route1 = _route_batch(coord1, data_index, noise_index, template, start_freqs)
         route2 = _route_batch(coord2, data_index, noise_index, template, start_freqs)
-        likes1 = coord1.compute_signal_likelihood(*route1[:3], route1[3])
-        likes2 = coord2.compute_signal_likelihood(*route2[:3], route2[3])
+        likes1 = coord1.cpp_signal_likelihood(*route1[:3], route1[3])
+        likes2 = coord2.cpp_signal_likelihood(*route2[:3], route2[3])
         np.testing.assert_allclose(likes1, likes2, rtol=1e-12)
 
     def test_run_threaded_matches_serial(self):
@@ -596,10 +596,10 @@ class TestComputeSignalLikelihoodPlacement(unittest.TestCase):
             coord, data_index, noise_index, template, start_freqs
         )
 
-        likes_serial = coord.compute_signal_likelihood(
+        likes_serial = coord.cpp_signal_likelihood(
             positions, data_intra, noise_intra, likelihood_args, run_threaded=False
         )
-        likes_threaded = coord.compute_signal_likelihood(
+        likes_threaded = coord.cpp_signal_likelihood(
             positions, data_intra, noise_intra, likelihood_args, run_threaded=True
         )
         np.testing.assert_array_equal(likes_serial, likes_threaded)
@@ -612,7 +612,7 @@ class TestComputeSignalLikelihoodPlacement(unittest.TestCase):
 
 class TestLoopOperationCallable(unittest.TestCase):
     """Bound-method dispatch is covered by compute_d_d_terms /
-    compute_signal_likelihood; here we verify the generic callable path
+    cpp_signal_likelihood; here we verify the generic callable path
     used for external per-device work (waveform generation, etc.)."""
 
     def test_callable_invoked_per_group_with_args(self):
@@ -796,7 +796,7 @@ class TestPlaceOnDevice(unittest.TestCase):
 class TestComposedLikelihoodFromCoords(unittest.TestCase):
     """The pre-merge ``compute_likelihood_from_coords`` convenience was
     removed; callers now compose ``unpack_indices`` + ``unpack_coords``
-    + ``_loop_operation`` + ``compute_signal_likelihood``. Verify the
+    + ``_loop_operation`` + ``cpp_signal_likelihood``. Verify the
     composition end to end against the per-binary reference."""
 
     def test_matches_per_binary_reference(self):
@@ -830,7 +830,7 @@ class TestComposedLikelihoodFromCoords(unittest.TestCase):
         likelihood_args = [
             out if out is not None else () for out in wf_out_per_split
         ]
-        likes = coord.compute_signal_likelihood(
+        likes = coord.cpp_signal_likelihood(
             positions, data_intra, noise_intra, likelihood_args
         )
 


### PR DESCRIPTION
## Summary

Retires the `DomainComputationGroupArray` (DCGA) **coordinator** by moving its
logic into `AnalysisContainerArray` (ACA). The fast C++ likelihood used to sit
behind two layers — per-split `*ComputationGroup` strategies **and** a DCGA
array-level coordinator that re-implemented multi-GPU split routing / threading /
device machinery ACA already owned. Now **ACA owns the cpp batched path
end-to-end**; the per-domain STFT/FD/WDM groups stay as slim per-split strategy
objects; and `DomainComputationGroupArray` survives only as a **deprecated thin
alias** for external settings files that still construct it.

Done phased so the suite is never red, one commit per step.

## What changed

**Coordinator retirement (Phases 0/A → already on this branch; B/C in this PR):**
- **B0–B3** — the 4 global-fit moves now drive `self.acs` directly instead of a
  held DCGA (`MultiGPUMoveBase`, `MultiGPUResidualAddRemoveMove`, `MultiGPUPSDMove`,
  `TDMBHSpecialMove`). The moves resolve the real ACA at their constructor
  boundary (`dcga.acs if hasattr(dcga, "acs") else dcga`), so external `dcga=`
  callers keep working. Per-split access goes through `acs.cpp_split(i)` /
  `acs.cpp_splits`.
- **C** — `DomainComputationGroupArray` trimmed to a permanent **deprecated thin
  alias** (`__init__`/`.acs`/`.computation_groups`/`.gpus`/`.num_splits`/`.xp` +
  `DeprecationWarning` on direct construction; ACA's `cpp_likelihood_backend`
  builds it with `_internal=True` to stay quiet). Removed the transitional
  `MultiGPUMoveBase.dcga`; renamed `BaseDomainComputationGroup` →
  `DomainKernelStrategy` (+ back-compat alias); dropped an unused `import jax`;
  refreshed ACA docstrings.

**Real-kernel test upgrades (follow-up after disproving a stale claim):**
- A prior note claimed the real FD kernel "diverges from the reference (~1.3)".
  An empirical check shows the real `FDDomainForStftWrap` `<d|h>`/`<h|h>` match
  the full-covariance `_cross_inner` reference to **~1e-15** — the claim was
  wrong. So the FD test now drives the **real `FDComputationGroup`** (NumPy stub
  deleted), same as WDM.
- Added **real-kernel STFT coverage** (`TestSTFTForwarderRealKernel`), which the
  suite previously lacked entirely. The STFT inner product is the FD full-cov
  product summed over time bins with the same `4·df` normalization
  (`diff_comp = df`; `FDDomainForStft` is literally `STFTDomain` with `NT=1`), so
  the same dimension-agnostic reference applies. Matches to ~3e-16.
- **All three domains (WDM/FD/STFT) now have real C++ kernel coverage.**

## Tests

Full CPU suite green (80 tests): `test_aca_cpp_likelihood_backend` (22),
`test_multi_gpu_placement` (21), `test_wdm_domain_cpp` (6), `test_band_view`
(15), `test_band_view_multi_shard` (11), `test_aca_vectorized_dispatch` (5).

> Note: the global-fit *move* package can't be imported in a CPU-only env
> (`eryn.paraensemble` is absent), so the move edits were verified by direct-load
> smokes + `py_compile` + the equivalence argument (the old shim methods were
> transparent `acs` forwarders, so each `self.dcga.X → self.acs.X` rewrite is
> behavior-identical). The ACA coordinator suites are the regression gate.

## Backward compatibility

`DomainComputationGroupArray(acs=acs)` still constructs and is accepted at every
move's constructor boundary — it just emits a `DeprecationWarning`. No external
caller change required.
