### PR TITLE
fix(erebor): keep TDI-on-the-fly wrapper output on-device

### DIFF
--- a/src/lisatools/globalfit/stock/erebor/wrappers.py
+++ b/src/lisatools/globalfit/stock/erebor/wrappers.py
@@ -267,12 +267,14 @@ class MBHTDIonFlyWaveWrap:
         # directly; drop the legacy ResponseWrapper kwarg if present.
         call_kwargs.pop("convert_to_ra_dec", None)
         m1, m2, s1z, s2z, dist, phi_ref, inc, psi, ra, dec, t_plunge = params
-        arr = np.asarray(
-            self.wave_gen(
-                m1, m2, s1z, s2z, dist, phi_ref, inc, ra, dec, psi, t_plunge,
-                upsample_t_arr=self.t_arr, combine=True, **call_kwargs,
-            )
+        raw = self.wave_gen(
+            m1, m2, s1z, s2z, dist, phi_ref, inc, ra, dec, psi, t_plunge,
+            upsample_t_arr=self.t_arr, combine=True, **call_kwargs,
         )
+        # Keep GPU-backend waveforms on-device.  CuPy deliberately rejects
+        # implicit conversion through np.asarray().
+        xp = get_array_module(raw[0] if isinstance(raw, (list, tuple)) else raw)
+        arr = xp.asarray(raw)
         if self.nchannels is not None:
             arr = arr[: self.nchannels]
         return arr
@@ -366,12 +368,12 @@ class SOBBHTDIonFlyWaveWrap:
         call_kwargs.update(kwargs)
         call_kwargs.pop("convert_to_ra_dec", None)
         m1, m2, s1, s2, dist, inc, f_low, ra, dec, psi, phi0 = params
-        arr = np.asarray(
-            self.wave_gen(
-                m1, m2, s1, s2, dist, f_low, phi0, inc, ra, dec, psi,
-                upsample_t_arr=self.t_arr, combine=True, **call_kwargs,
-            )
+        raw = self.wave_gen(
+            m1, m2, s1, s2, dist, f_low, phi0, inc, ra, dec, psi,
+            upsample_t_arr=self.t_arr, combine=True, **call_kwargs,
         )
+        xp = get_array_module(raw[0] if isinstance(raw, (list, tuple)) else raw)
+        arr = xp.asarray(raw)
         if self.nchannels is not None:
             arr = arr[: self.nchannels]
         return arr


### PR DESCRIPTION
Every GPU TDI-on-the-fly run currently dies with:

```
TypeError: Implicit conversion to a NumPy array is not allowed.
```

`MBHTDIonFlyWaveWrap.raw_td` (~L270) and `SOBBHTDIonFlyWaveWrap.raw_td` (~L368) in `src/lisatools/globalfit/stock/erebor/wrappers.py` wrap their generator call in `np.asarray`. `MBHTDIonFly` correctly returns CuPy under `force_backend="cuda12x"`, and CuPy deliberately refuses implicit conversion.

This resolves the array module from the returned data via `get_array_module` and uses `xp.asarray`, which also avoids a device→host round trip on the GPU path.

`SOBBHWaveWrap` in the same module is already backend-safe — this makes the two TDIonFly wraps consistent with it, per the repo's `xp` pattern.

Context: one of three patches needed to get the MBH GPU global fit running on ACCRE — https://github.com/lisa-analysis-tools/lisa-analysis-tools/issues/77

🤖 Generated with [Claude Code](https://claude.com/claude-code)