### PR TITLE
perf(plots): make LaTeX text rendering opt-in via LISATOOLS_USETEX

### DIFF
--- a/src/lisatools/globalfit/diagnosticplot.py
+++ b/src/lisatools/globalfit/diagnosticplot.py
@@ -38,7 +38,16 @@ def set_plotting_style(background_color: str = "white", front_color: str = "blac
     # text settings -- only enable LaTeX rendering when latex is actually
     # installed, else matplotlib crashes on machines without it (fall back to
     # mathtext). Applies to every global-fit plot (grid-gen, debug, diag).
-    _has_latex = shutil.which("latex") is not None
+    # usetex shells out to a LaTeX process for EVERY text layout. On a cluster
+    # with latex on PATH that measured ~487 s across 5 calls of
+    # matplotlib.text._get_layout (with a stray luatex child alive for
+    # minutes) -- comparable to the entire compute of a short run. mathtext
+    # renders the same labels with no subprocess, so LaTeX is now opt-in via
+    # LISATOOLS_USETEX=1 rather than "on whenever latex happens to exist".
+    _has_latex = (
+        os.environ.get("LISATOOLS_USETEX", "0") not in ("0", "")
+        and shutil.which("latex") is not None
+    )
     mpl.rcParams["text.usetex"] = _has_latex  # Use LaTeX for text rendering
     if _has_latex:
         mpl.rcParams["text.latex.preamble"] = r"\usepackage{amsmath}"  # AMS math
@@ -254,7 +263,12 @@ def base_branch_plots(
 
         plot_config = {
             "serif": True,
-            "usetex": shutil.which("latex") is not None,
+            # Opt-in, same reason as set_plotting_style: LaTeX text layout
+            # costs a subprocess per label.
+            "usetex": (
+                os.environ.get("LISATOOLS_USETEX", "0") not in ("0", "")
+                and shutil.which("latex") is not None
+            ),
             "spacing": 1.5,
         }
         C.set_plot_config(chainconsumer.PlotConfig(**plot_config))


### PR DESCRIPTION
**This changes a default** — flagging it explicitly rather than slipping it in.

`set_plotting_style` sets `text.usetex = shutil.which("latex") is not None`, and the chainconsumer `plot_config` in `base_branch_plots` repeats the same test. Where latex exists on PATH, matplotlib shells out to a LaTeX process for **every text layout**.

Measured on ACCRE: **~487 s across 5 calls** of `matplotlib.text._get_layout`, with a stray luatex child alive for minutes. This fires even with `MAKE_DIAGNOSTIC_PLOTS=0` — something still draws. Combined with ~400 s of import I/O off the shared filesystem, a 1-iteration MBH global fit spent ~800 s starting up to do 226 s of actual work.

It amortizes over a long run but dominates any short one, and mathtext renders the same labels with no subprocess — so the cost is not buying anything by default.

After this PR: LaTeX is opt-in via `LISATOOLS_USETEX=1`, applied at both sites. Previous behaviour is one env var away.

Happy to invert the default (opt-*out*) if you'd rather keep LaTeX on for anyone who has it.

Context: https://github.com/lisa-analysis-tools/lisa-analysis-tools/issues/77

🤖 Generated with [Claude Code](https://claude.com/claude-code)