### PR TITLE
perf(tdionfly): cache configured Orbits instead of deepcopying per evaluation

### DIFF
--- a/src/lisatools/response/tdionfly.py
+++ b/src/lisatools/response/tdionfly.py
@@ -19,11 +19,83 @@ except (ImportError, ModuleNotFoundError) as e:
 from scipy.interpolate import CubicSpline as CubicSpline_scipy
 from gpubackendtools.interpolate import CubicSplineInterpolant
 
+
+# ---------------------------------------------------------------------------
+# Configured-orbits cache
+# ---------------------------------------------------------------------------
+# ``TDIonTheFly`` is constructed once per waveform evaluation, and its
+# ``orbits`` setter used to ``deepcopy`` the incoming (unconfigured) Orbits and
+# then trigger lazy configuration. ``Orbits._configure`` re-runs a scipy
+# CubicSpline over every orbit table component, which profiling (job 12930220)
+# measured at ~752 s of the 984 s spent in the MBH waveform call -- ~76% of the
+# whole run, redone identically on every call.
+#
+# ``_configure`` writes only plain numpy state (_ltt/_x/_n/_v, t, dt,
+# pycppdetector_args) and is backend-independent, so one configured instance is
+# reusable everywhere the configuration inputs match. Entries are shared, not
+# copied: copying a configured Orbits is itself GBs of memcpy. The response
+# path treats orbits as read-only; set ``LISATOOLS_ORBITS_CACHE=0`` to restore
+# the old per-instance deepcopy if you need to mutate them.
+_ORBITS_CONFIGURED_CACHE: dict = {}
+
+
+def _orbits_cache_key(orbits) -> Optional[tuple]:
+    """Identity of everything ``Orbits._configure`` depends on, or None."""
+    try:
+        parts = [
+            type(orbits).__module__,
+            type(orbits).__name__,
+            getattr(orbits, "frame", None),
+            getattr(orbits, "armlength", None),
+            getattr(orbits, "t0", None),
+            getattr(orbits, "filename", None),
+        ]
+        for name, val in sorted(getattr(orbits, "_configure_kwargs", {}).items()):
+            if isinstance(val, np.ndarray):
+                # hash contents: t_arr defines the output grid exactly
+                parts.append((name, val.shape, val.dtype.str, hash(val.tobytes())))
+            else:
+                parts.append((name, val))
+        return tuple(parts)
+    except Exception:
+        # Anything unhashable / unexpected -> no caching, old behaviour.
+        return None
+
+
+def _get_configured_orbits(orbits):
+    """Return a configured Orbits for ``orbits``, reusing an identical one."""
+    import os
+
+    if os.environ.get("LISATOOLS_ORBITS_CACHE", "1") == "0":
+        out = deepcopy(orbits)
+        out.pycppdetector_args
+        return out
+
+    if getattr(orbits, "configured", False):
+        # Already configured by the caller: honour it, don't re-spline.
+        return orbits
+
+    key = _orbits_cache_key(orbits)
+    if key is None:
+        out = deepcopy(orbits)
+        out.pycppdetector_args
+        return out
+
+    cached = _ORBITS_CONFIGURED_CACHE.get(key)
+    if cached is None:
+        cached = deepcopy(orbits)
+        # Force the (expensive) lazy configuration exactly once per key.
+        cached.pycppdetector_args
+        _ORBITS_CONFIGURED_CACHE[key] = cached
+    return cached
+
 from lisatools.detector import EqualArmlengthOrbits, Orbits
 from lisatools.utils.utility import AET
 from gpubackendtools import wrapper
             
 from ..utils.parallelbase import LISAToolsParallelModule
+from ..utils.stagetimer import TIMING, TIMERS, TIMER_COUNTS
+from ..utils.stagetimer import stage as _stage
 from .tdiconfig import TDIConfig
 
 # TODO: need to update constants setup
@@ -99,8 +171,10 @@ class TDIonTheFly(LISAToolsParallelModule):
         super().__init__(force_backend=force_backend)
 
         # setup orbits
-        self.orbits = orbits
-        self.tdi_config = tdi_config
+        with _stage("3a_orbits_setter", self.xp):
+            self.orbits = orbits
+        with _stage("3b_tdi_config_setter", self.xp):
+            self.tdi_config = tdi_config
         # setup TDI info
         
     @property
@@ -140,10 +214,14 @@ class TDIonTheFly(LISAToolsParallelModule):
         else:
             assert isinstance(orbits, Orbits)
 
-        self._orbits = deepcopy(orbits)
+        # Reuses an identically-configured Orbits instead of re-splining the
+        # orbit tables on every waveform call. See _get_configured_orbits.
+        with _stage("3a1_get_configured_orbits", self.xp):
+            self._orbits = _get_configured_orbits(orbits)
 
         # pycppdetector_args triggers lazy configuration if needed.
-        self.cpp_orbits = self.backend.OrbitsWrap(*self._orbits.pycppdetector_args)
+        with _stage("3a2_OrbitsWrap", self.xp):
+            self.cpp_orbits = self.backend.OrbitsWrap(*self._orbits.pycppdetector_args)
     
     @property
     def citation(self):
@@ -172,13 +250,15 @@ class TDIonTheFly(LISAToolsParallelModule):
         phase_ref = self.xp.zeros((self.N * self.num_sub), dtype=float)
         assert int(np.prod(self.t_arr.shape)) == self.N * self.num_sub
 
-        self.wave_gen.run_wave_tdi_wrap(
-            tdi_channels_arr,
-            tdi_amp, tdi_phase,
-            phase_ref,
-            params, self.t_arr.flatten().copy(),
-            self.N, self.num_sub, self.n_params, self.tdi_config.nchannels
-        )
+        _wg = self.wave_gen
+        with _stage("4b_run_wave_tdi_kernel", self.xp):
+            _wg.run_wave_tdi_wrap(
+                tdi_channels_arr,
+                tdi_amp, tdi_phase,
+                phase_ref,
+                params, self.t_arr.flatten().copy(),
+                self.N, self.num_sub, self.n_params, self.tdi_config.nchannels
+            )
         
         reshape_shape = (self.num_sub, self.tdi_config.nchannels, self.N)
         # Propagate THIS generator's backend to the output object (as the four
@@ -187,7 +267,7 @@ class TDIonTheFly(LISAToolsParallelModule):
         # to CUDA on any cupy-equipped box regardless of the generator's actual
         # backend -- so a CPU/numpy generator's arrays hit a cuda interpolant
         # in build_spline and raise the nanobind device mismatch.
-        return self.from_tdi_output(TDIOutput(
+        return self._timed_from_tdi_output(TDIOutput(
             self.t_arr,
             tdi_amp.reshape(reshape_shape),
             tdi_phase.reshape(reshape_shape),
@@ -195,6 +275,10 @@ class TDIonTheFly(LISAToolsParallelModule):
             force_backend=self.backend.name.split("_")[-1],
         ), fill_splines=return_spline)
     
+    def _timed_from_tdi_output(self, tdi_output, fill_splines=False):
+        with _stage("4c_from_tdi_output_splines", self.xp):
+            return self.from_tdi_output(tdi_output, fill_splines=fill_splines)
+
     def from_tdi_output(self, tdi_output: TDIOutput, fill_splines: Optional[bool] = False) -> FDTDIOutput:
         return tdi_output
 
@@ -236,8 +320,9 @@ class TDTDIonTheFly(TDIonTheFly):
             phase = self.xp.atleast_2d(self.xp.asarray(phase))
 
             # TODO: improve when gbt is fixed up
-            amp = CubicSplineInterpolant(t_input.copy(), amp, force_backend=self.backend.name.split("_")[-1])
-            phase = CubicSplineInterpolant(t_input.copy(), phase, force_backend=self.backend.name.split("_")[-1])
+            with _stage("3c_ampphase_spline_build", self.xp):
+                amp = CubicSplineInterpolant(t_input.copy(), amp, force_backend=self.backend.name.split("_")[-1])
+                phase = CubicSplineInterpolant(t_input.copy(), phase, force_backend=self.backend.name.split("_")[-1])
             
         elif isinstance(amp, CubicSpline_scipy):
             raise NotImplementedError
@@ -294,9 +379,10 @@ class TDTDIonTheFly(TDIonTheFly):
         # time.sleep(1.0)
     @property
     def wave_gen(self) -> callable:
-        self.cpp_amp = self.backend.CubicSplineWrap(*self.amp.cpp_class_args)
-        self.cpp_phase = self.backend.CubicSplineWrap(*self.phase.cpp_class_args)
-        self._wave_gen = self.backend.TDSplineTDIWaveformWrap(self.cpp_orbits, self.cpp_tdi_config, self.cpp_amp, self.cpp_phase)
+        with _stage("4a_wave_gen_wrap_build", self.xp):
+            self.cpp_amp = self.backend.CubicSplineWrap(*self.amp.cpp_class_args)
+            self.cpp_phase = self.backend.CubicSplineWrap(*self.phase.cpp_class_args)
+            self._wave_gen = self.backend.TDSplineTDIWaveformWrap(self.cpp_orbits, self.cpp_tdi_config, self.cpp_amp, self.cpp_phase)
         return self._wave_gen
     
     def from_tdi_output(self, tdi_output: TDIOutput, fill_splines: Optional[bool] = False) -> FDTDIOutput:

--- a/src/lisatools/utils/stagetimer.py
+++ b/src/lisatools/utils/stagetimer.py
@@ -1,0 +1,105 @@
+"""Opt-in, device-synced stage timing for hot evaluation paths.
+
+cProfile is a poor tool for these paths: GPU kernels are asynchronous, so the
+cost lands on whichever python frame next synchronizes, and python-heavy frames
+are inflated ~3x by the profiler itself. These helpers accumulate wall time with
+an explicit device sync at each stage boundary instead.
+
+Off by default (near-zero overhead); enable with ``MBHTDIONFLY_TIMING=1``.
+Dump with :func:`report_timing`.
+"""
+
+import os
+import time
+from collections import defaultdict
+
+import numpy as np
+
+TIMING: bool = os.environ.get("MBHTDIONFLY_TIMING", "0") != "0"
+TIMERS: dict = defaultdict(float)
+TIMER_COUNTS: dict = defaultdict(int)
+
+
+def _sync(xp) -> None:
+    if xp is not np:
+        try:
+            xp.cuda.runtime.deviceSynchronize()
+        except Exception:
+            pass
+
+
+class stage:
+    """Context manager accumulating device-synced wall time into ``TIMERS``."""
+
+    __slots__ = ("name", "xp", "t0")
+
+    def __init__(self, name: str, xp):
+        self.name = name
+        self.xp = xp
+
+    def __enter__(self):
+        if TIMING:
+            _sync(self.xp)
+            self.t0 = time.perf_counter()
+        return self
+
+    def __exit__(self, *exc):
+        if TIMING:
+            _sync(self.xp)
+            TIMERS[self.name] += time.perf_counter() - self.t0
+            TIMER_COUNTS[self.name] += 1
+        return False
+
+
+def record(name: str, dt: float) -> None:
+    """Add ``dt`` seconds to the ``name`` accumulator (already synced)."""
+    TIMERS[name] += dt
+    TIMER_COUNTS[name] += 1
+
+
+def _atexit_report() -> None:  # pragma: no cover - diagnostic only
+    print("\n" + report_timing(), flush=True)
+
+
+def _signal_report(signum, frame) -> None:  # pragma: no cover - diagnostic only
+    """Dump on SIGTERM/SIGINT.
+
+    Slurm sends SIGTERM before SIGKILL at walltime; without this a job that
+    runs out of time loses the whole accumulated report, since atexit does not
+    run on an uncaught fatal signal.
+    """
+    print(f"\n[stagetimer] signal {signum} -- dumping accumulated timers",
+          flush=True)
+    print(report_timing(), flush=True)
+    signal.signal(signum, signal.SIG_DFL)
+    os.kill(os.getpid(), signum)
+
+
+if TIMING:
+    import atexit
+    import signal
+
+    atexit.register(_atexit_report)
+    for _sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            signal.signal(_sig, _signal_report)
+        except (ValueError, OSError):
+            pass  # not on the main thread / not supported here
+
+
+def report_timing(reset: bool = False) -> str:
+    """Human-readable dump of the accumulated stage timers."""
+    if not TIMERS:
+        return "stage timing: no data (set MBHTDIONFLY_TIMING=1)"
+    total = TIMERS.get("total") or sum(TIMERS.values())
+    lines = ["stage timing (device-synced wall seconds):"]
+    for name, val in sorted(TIMERS.items(), key=lambda kv: -kv[1]):
+        n = TIMER_COUNTS[name]
+        lines.append(
+            f"  {name:<30s} {val:9.2f} s  {100 * val / total:5.1f}%  "
+            f"{n:6d} calls  {val / max(n, 1):8.4f} s/call"
+        )
+    if reset:
+        TIMERS.clear()
+        TIMER_COUNTS.clear()
+    return "\n".join(lines)


### PR DESCRIPTION
**Draft** — please sanity-check the approach before I clean it up. Two topics landed in one file (see bottom); I'll split them if you want this.

### The problem

`TDIonTheFly` is constructed once per waveform evaluation, and its `orbits` setter does `self._orbits = deepcopy(orbits)`. The deepcopy discards the incoming Orbits' lazy configuration, so the next `pycppdetector_args` access re-runs `Orbits._configure`, re-splining every orbit table component — identically, on the CPU, every single call.

cProfile of the MBH waveform path: **752 s of 984 s**, with the **GPU at 0%** utilization and the process single-core bound.

### The change

A module-level cache of configured `Orbits`, keyed on what `_configure` depends on (type, `frame`, `armlength`, `t0`, `filename`, `_configure_kwargs`), which **shares** rather than copies — copying a configured `Orbits` is itself GBs of memcpy.

The reasoning I'd like checked: `_configure` writes only plain NumPy state and is backend-independent, so the instance looked reusable to me, and the response path appears to treat orbits as read-only. **If there's a reason the deepcopy was there, this is where it breaks.**

**640 → 352 s/iteration, bit-identical output.** `LISATOOLS_ORBITS_CACHE=0` restores the old behaviour.

### Also in this branch (would split before merge)

Stage timers plus a new `lisatools.utils.stagetimer` module, inert unless `MBHTDIONFLY_TIMING=1`. Device-synced, because cProfile mis-attributes async GPU work and inflates ~2.9x — these produced the per-eval breakdown in the issue.

Context: https://github.com/lisa-analysis-tools/lisa-analysis-tools/issues/77

🤖 Generated with [Claude Code](https://claude.com/claude-code)